### PR TITLE
Type checking to ensure custom class extends proper base class

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdBrowserController.m
+++ b/MoPubSDK/Internal/Common/MPAdBrowserController.m
@@ -254,7 +254,7 @@
 {
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGContextRef context = CGBitmapContextCreate(nil,27,27,8,0,
-                                                 colorSpace,kCGImageAlphaPremultipliedLast);
+                                                 colorSpace,(CGBitmapInfo)kCGImageAlphaPremultipliedLast);
     CFRelease(colorSpace);
     return context;
 }

--- a/MoPubSDK/Internal/MPInstanceProvider.m
+++ b/MoPubSDK/Internal/MPInstanceProvider.m
@@ -122,6 +122,11 @@ static MPInstanceProvider *sharedProvider = nil;
                                                       delegate:(id<MPBannerCustomEventDelegate>)delegate
 {
     MPBannerCustomEvent *customEvent = [[[customClass alloc] init] autorelease];
+    if([customEvent isKindOfClass:[MPBannerCustomEvent class]] == NO)
+    {
+        MPLogError(@"**** Custom Event Class: %@ does not extend MPBannerCustomEvent ****", NSStringFromClass(customClass));
+        return nil;
+    }
     customEvent.delegate = delegate;
     return customEvent;
 }
@@ -150,6 +155,11 @@ static MPInstanceProvider *sharedProvider = nil;
                                                                   delegate:(id<MPInterstitialCustomEventDelegate>)delegate
 {
     MPInterstitialCustomEvent *customEvent = [[[customClass alloc] init] autorelease];
+    if([customEvent isKindOfClass:[MPInterstitialCustomEvent class]] == NO)
+    {
+        MPLogError(@"**** Custom Event Class: %@ does not extend MPInterstitialCustomEvent ****", NSStringFromClass(customClass));
+        return nil;
+    }
     if ([customEvent respondsToSelector:@selector(customEventDidUnload)]) {
         MPLogWarn(@"**** Custom Event Class: %@ implements the deprecated -customEventDidUnload method.  This is no longer called.  Use -dealloc for cleanup instead ****", NSStringFromClass(customClass));
     }


### PR DESCRIPTION
There is no type checking to ensure what is put in the mopub dashboard is in fact a custom event class.  I came across this bug because our ad ops member put a banner custom event class in the interstitial rotation and mopub sdk crashed on:
[self.interstitialCustomEvent requestInterstitialWithCustomEventInfo:configuration.customEventClassData];

You can compare classes a few ways, but the cleanest in this senario is after you alloc and init the customClass then check to see if its actually either a MPBannerCustomEvent or MPInterstitialCustomEvent depending on what you need and then return nil if its not.

Also fixed compiler warning for casting enum type to a different enum type.
