### PR TITLE
Prevent loading banners while in background.

### DIFF
--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -28,6 +28,7 @@
 @property (nonatomic, assign) BOOL automaticallyRefreshesContents;
 @property (nonatomic, assign) BOOL hasRequestedAtLeastOneAd;
 @property (nonatomic, assign) UIInterfaceOrientation currentOrientation;
+@property (nonatomic, assign) BOOL appIsInBackground;
 
 - (void)loadAdWithURL:(NSURL *)URL;
 - (void)applicationWillEnterForeground;
@@ -111,6 +112,7 @@
 
 - (void)applicationWillEnterForeground
 {
+    self.appIsInBackground = NO;
     if (self.automaticallyRefreshesContents && self.hasRequestedAtLeastOneAd) {
         [self loadAdWithURL:nil];
     }
@@ -119,6 +121,7 @@
 - (void)applicationDidEnterBackground
 {
     [self pauseRefreshTimer];
+    self.appIsInBackground = YES;
 }
 
 - (void)pauseRefreshTimer
@@ -156,6 +159,12 @@
     self.requestingAdapterAdContentView = nil;
 
     [self.communicator cancel];
+    
+    if(self.appIsInBackground)
+    {
+        MPLogInfo(@"Banner view (%@) not loading due to app being in background", [self.delegate adUnitId]);
+        return;
+    }
 
     URL = (URL) ? URL : [MPAdServerURLBuilder URLWithAdUnitID:[self.delegate adUnitId]
                                                      keywords:[self.delegate keywords]


### PR DESCRIPTION
This prevents the behavior of banners loading while the app is in the background. Calling `pauseRefreshTimer` alone upon entering background is insufficient as other timers and items currently loading can cause an ad to load or the refresh timer to restart while still in the background.