### PR TITLE
Sort visible items indexPaths array for proper visibility comparison.

### DIFF
--- a/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
@@ -117,7 +117,7 @@
 {
     BOOL animationsWereEnabled = [UIView areAnimationsEnabled];
     //We only want to enable animations if the index path is before or within our visible cells
-    BOOL animationsEnabled = ([(NSIndexPath *)[self.collectionView.indexPathsForVisibleItems lastObject] compare:indexPath] != NSOrderedAscending) && animationsWereEnabled;
+    BOOL animationsEnabled = ([(NSIndexPath *)[[self.collectionView.indexPathsForVisibleItems sortedArrayUsingSelector:@selector(compare:)] lastObject] compare:indexPath] != NSOrderedAscending) && animationsWereEnabled;
 
     [UIView setAnimationsEnabled:animationsEnabled];
 


### PR DESCRIPTION
indexPathsForVisibleItems: results aren't sorted so this test could easily fail unless we sort the array before comparing to the given index.

This might need to be fixed for the tableView ad placer too.