### PR TITLE
Added safety fixes for delegates, warnings and analytical warnings in Xcode 6.2

### DIFF
--- a/AdNetworkSupport/Facebook/FacebookBannerCustomEvent.m
+++ b/AdNetworkSupport/Facebook/FacebookBannerCustomEvent.m
@@ -77,6 +77,12 @@
     }
 
     MPLogInfo(@"Requesting Facebook banner ad");
+    
+    if (self.fbAdView) {
+        self.fbAdView.delegate = nil;
+        [self.fbAdView removeFromSuperview];
+    }
+    
     self.fbAdView =
         [[MPInstanceProvider sharedProvider] buildFBAdViewWithPlacementID:[info objectForKey:@"placement_id"]
                                                                      size:fbAdSize
@@ -102,7 +108,10 @@
 
 - (void)dealloc
 {
-    _fbAdView.delegate = nil;
+    if (self.fbAdView) {
+        self.fbAdView.delegate = nil;
+        [self.fbAdView removeFromSuperview];
+    }
 }
 
 #pragma mark FBAdViewDelegate methods

--- a/AdNetworkSupport/Facebook/FacebookInterstitialCustomEvent.m
+++ b/AdNetworkSupport/Facebook/FacebookInterstitialCustomEvent.m
@@ -47,6 +47,10 @@
     }
 
     MPLogInfo(@"Requesting Facebook interstitial ad");
+    
+    if (self.fbInterstitialAd) {
+        self.fbInterstitialAd.delegate = nil;
+    }
 
     self.fbInterstitialAd =
     [[MPInstanceProvider sharedProvider] buildFBInterstitialAdWithPlacementID:[info objectForKey:@"placement_id"]
@@ -70,7 +74,9 @@
 
 - (void)dealloc
 {
-    _fbInterstitialAd.delegate = nil;
+    if (self.fbInterstitialAd) {
+        self.fbInterstitialAd.delegate = nil;
+    }
 }
 
 #pragma mark FBInterstitialAdDelegate methods

--- a/AdNetworkSupport/Facebook/FacebookNativeAdAdapter.m
+++ b/AdNetworkSupport/Facebook/FacebookNativeAdAdapter.m
@@ -76,6 +76,13 @@
     return self;
 }
 
+- (void)dealloc
+{
+    if (_fbNativeAd) {
+        [_fbNativeAd unregisterView];
+        _fbNativeAd.delegate = nil;
+    }
+}
 
 #pragma mark - MPNativeAdAdapter
 

--- a/AdNetworkSupport/Facebook/FacebookNativeCustomEvent.m
+++ b/AdNetworkSupport/Facebook/FacebookNativeCustomEvent.m
@@ -22,15 +22,31 @@ static const NSInteger FacebookNoFillErrorCode = 1001;
 
 @implementation FacebookNativeCustomEvent
 
+- (void)dealloc
+{
+    if (_fbNativeAd) {
+        [_fbNativeAd unregisterView];
+        _fbNativeAd.delegate = nil;
+    }
+}
+
 - (void)requestAdWithCustomEventInfo:(NSDictionary *)info
 {
     NSString *placementID = [info objectForKey:@"placement_id"];
 
     if (placementID) {
+        
+        if (_fbNativeAd) {
+            [_fbNativeAd unregisterView];
+            _fbNativeAd.delegate = nil;
+        }
+        
         _fbNativeAd = [[FBNativeAd alloc] initWithPlacementID:placementID];
         self.fbNativeAd.delegate = self;
         [self.fbNativeAd loadAd];
+        
     } else {
+        
         [self.delegate nativeCustomEvent:self didFailToLoadAdWithError:[NSError errorWithDomain:MoPubNativeAdsSDKDomain code:MPNativeAdErrorInvalidServerResponse userInfo:nil]];
     }
 }

--- a/AdNetworkSupport/InMobi/InMobiBannerCustomEvent.m
+++ b/AdNetworkSupport/InMobi/InMobiBannerCustomEvent.m
@@ -64,6 +64,11 @@ static NSString *gAppId = nil;
     if ([appId length] == 0) {
         appId = kInMobiAppID;
     }
+    
+    if (self.inMobiBanner) {
+        self.inMobiBanner.delegate = nil;
+        [self.inMobiBanner removeFromSuperview];
+    }
 
     self.inMobiBanner = [[MPInstanceProvider sharedProvider] buildIMBannerWithFrame:CGRectMake(0, 0, size.width, size.height) appId:appId adSize:imAdSizeConstant];
     self.inMobiBanner.delegate = self;
@@ -104,7 +109,10 @@ static NSString *gAppId = nil;
 
 - (void)dealloc
 {
-    [self.inMobiBanner setDelegate:nil];
+    if (self.inMobiBanner) {
+        self.inMobiBanner.delegate = nil;
+        [self.inMobiBanner removeFromSuperview];
+    }
 }
 
 #pragma mark - IMAdDelegate

--- a/AdNetworkSupport/InMobi/InMobiInterstitialCustomEvent.m
+++ b/AdNetworkSupport/InMobi/InMobiInterstitialCustomEvent.m
@@ -59,6 +59,11 @@ static NSString *gAppId = nil;
     if ([appId length] == 0) {
         appId = kInMobiAppID;
     }
+    
+    if (self.inMobiInterstitial) {
+        self.inMobiInterstitial.delegate = nil;
+        self.inMobiInterstitial.incentivisedDelegate = nil;
+    }
 
     self.inMobiInterstitial = [[MPInstanceProvider sharedProvider] buildIMInterstitialWithDelegate:self appId:appId];
     NSMutableDictionary *paramsDict = [NSMutableDictionary dictionary];
@@ -80,7 +85,10 @@ static NSString *gAppId = nil;
 
 - (void)dealloc
 {
-    [self.inMobiInterstitial setDelegate:nil];
+    if (self.inMobiInterstitial) {
+        self.inMobiInterstitial.delegate = nil;
+        self.inMobiInterstitial.incentivisedDelegate = nil;
+    }
 }
 
 #pragma mark - IMAdInterstitialDelegate

--- a/AdNetworkSupport/InMobi/InMobiNativeAdAdapter.m
+++ b/AdNetworkSupport/InMobi/InMobiNativeAdAdapter.m
@@ -135,8 +135,10 @@ static NSString *const kInMobiImageURL = @"url";
 
 - (void)dealloc
 {
-    [_destinationDisplayAgent cancel];
-    [_destinationDisplayAgent setDelegate:nil];
+    if (_destinationDisplayAgent) {
+        [_destinationDisplayAgent cancel];
+        [_destinationDisplayAgent setDelegate:nil];
+    }
 }
 
 - (NSDictionary *)inMobiProperties

--- a/AdNetworkSupport/InMobi/InMobiNativeCustomEvent.m
+++ b/AdNetworkSupport/InMobi/InMobiNativeCustomEvent.m
@@ -31,7 +31,9 @@ static NSString *gAppId = nil;
 
 - (void)dealloc
 {
-    _inMobiAd.delegate = nil;
+    if (_inMobiAd) {
+        _inMobiAd.delegate = nil;
+    }
 }
 
 - (void)requestAdWithCustomEventInfo:(NSDictionary *)info
@@ -43,10 +45,17 @@ static NSString *gAppId = nil;
     }
 
     if ([appId length]) {
+        
+        if (_inMobiAd) {
+            _inMobiAd.delegate = nil;
+        }
+        
         _inMobiAd = [[IMNative alloc] initWithAppId:appId];
         self.inMobiAd.delegate = self;
         [self.inMobiAd loadAd];
+        
     } else {
+        
         [self.delegate nativeCustomEvent:self didFailToLoadAdWithError:[NSError errorWithDomain:MoPubNativeAdsSDKDomain code:MPNativeAdErrorInvalidServerResponse userInfo:nil]];
     }
 }

--- a/AdNetworkSupport/Millennial/MPMillennialBannerCustomEvent.m
+++ b/AdNetworkSupport/Millennial/MPMillennialBannerCustomEvent.m
@@ -100,6 +100,11 @@
 {
     self.mmCompletionBlockProxy.event = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    
+    if (self.mmAdView) {
+        self.mmAdView.rootViewController = nil;
+        [self.mmAdView removeFromSuperview];
+    }
 }
 
 - (void)requestAdWithSize:(CGSize)size customEventInfo:(NSDictionary *)info
@@ -108,6 +113,12 @@
 
     CGRect frame = [self frameFromCustomEventInfo:info];
     NSString *apid = [info objectForKey:@"adUnitID"];
+    
+    if (self.mmAdView) {
+        self.mmAdView.rootViewController = nil;
+        [self.mmAdView removeFromSuperview];
+    }
+    
     self.mmAdView = [[MPInstanceProvider sharedProvider] buildMMAdViewWithFrame:frame
                                                                            apid:apid
                                                              rootViewController:self.delegate.viewControllerForPresentingModalView];

--- a/AdNetworkSupport/iAd/MPiAdBannerCustomEvent.m
+++ b/AdNetworkSupport/iAd/MPiAdBannerCustomEvent.m
@@ -110,7 +110,10 @@
 
 - (void)rotateToOrientation:(UIInterfaceOrientation)orientation
 {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     self.bannerView.currentContentSizeIdentifier = UIInterfaceOrientationIsPortrait(orientation) ? ADBannerContentSizeIdentifierPortrait : ADBannerContentSizeIdentifierLandscape;
+    #pragma GCC diagnostic pop
 }
 
 - (void)didDisplayAd

--- a/MoPubSDK/Internal/MPInstanceProvider.m
+++ b/MoPubSDK/Internal/MPInstanceProvider.m
@@ -141,7 +141,11 @@ static MPInstanceProvider *sharedAdProvider = nil;
         MPLogError(@"**** Custom Event Class: %@ does not extend MPInterstitialCustomEvent ****", NSStringFromClass(customClass));
         return nil;
     }
+    
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wundeclared-selector"
     if ([customEvent respondsToSelector:@selector(customEventDidUnload)]) {
+    #pragma GCC diagnostic pop
         MPLogWarn(@"**** Custom Event Class: %@ implements the deprecated -customEventDidUnload method.  This is no longer called.  Use -dealloc for cleanup instead ****", NSStringFromClass(customClass));
     }
     customEvent.delegate = delegate;

--- a/MoPubSDK/Internal/Utility/Categories/UIViewController+MPAdditions.m
+++ b/MoPubSDK/Internal/Utility/Categories/UIViewController+MPAdditions.m
@@ -47,7 +47,7 @@
     }
 #endif
 
-    [self presentModalViewController:modalViewController animated:animated];
+    [self presentViewController:modalViewController animated:animated completion:nil];
 }
 
 - (void)mp_dismissModalViewControllerAnimated:(BOOL)animated
@@ -59,7 +59,7 @@
     }
 #endif
 
-    [self dismissModalViewControllerAnimated:animated];
+    [self dismissViewControllerAnimated:animated completion:nil];
 }
 
 @end

--- a/MoPubSDK/Internal/Utility/MPGeolocationProvider.m
+++ b/MoPubSDK/Internal/Utility/MPGeolocationProvider.m
@@ -243,9 +243,11 @@ const NSTimeInterval kMPLocationUpdateInterval = 10.0 * 60.0;
         case kCLAuthorizationStatusRestricted:
             self.authorizedForLocationServices = NO;
             break;
-        case kCLAuthorizationStatusAuthorized: // same as kCLAuthorizationStatusAuthorizedAlways
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+        case kCLAuthorizationStatusAuthorizedAlways:
         case kCLAuthorizationStatusAuthorizedWhenInUse:
+#else
+        case kCLAuthorizationStatusAuthorized: // same as kCLAuthorizationStatusAuthorizedAlways
 #endif
             self.authorizedForLocationServices = YES;
             break;

--- a/MoPubSDK/MoPub.m
+++ b/MoPubSDK/MoPub.m
@@ -53,7 +53,11 @@
 - (void)initializeRewardedVideoWithGlobalMediationSettings:(NSArray *)globalMediationSettings delegate:(id<MPRewardedVideoDelegate>)delegate
 {
     // initializeWithDelegate: is a known private initialization method on MPRewardedVideo. So we forward the initialization call to that class.
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wundeclared-selector"
     [MPRewardedVideo performSelector:@selector(initializeWithDelegate:) withObject:delegate];
+    #pragma GCC diagnostic pop
+    
     self.globalMediationSettings = globalMediationSettings;
 }
 

--- a/MoPubSDK/Native Ads/Internal/MPNativePositionResponseDeserializer.m
+++ b/MoPubSDK/Native Ads/Internal/MPNativePositionResponseDeserializer.m
@@ -213,19 +213,25 @@ static NSInteger const MPMaxRepeatingInterval = 1 << 16;
 
 #pragma mark - Error helpers
 
-- (void)safeAssignError:(NSError **)error code:(MPNativePositionResponseDeserializationErrorCode)code userInfo:(NSDictionary *)userInfo
+- (BOOL)safeAssignError:(NSError **)error code:(MPNativePositionResponseDeserializationErrorCode)code userInfo:(NSDictionary *)userInfo
 {
     if (error) {
+        
         *error = [self deserializationErrorWithCode:code userInfo:userInfo];
+        if (*error) {
+            return NO;
+        }
     }
+    
+    return YES;
 }
 
-- (void)safeAssignError:(NSError **)error code:(MPNativePositionResponseDeserializationErrorCode)code description:(NSString *)description
+- (BOOL)safeAssignError:(NSError **)error code:(MPNativePositionResponseDeserializationErrorCode)code description:(NSString *)description
 {
-    [self safeAssignError:error code:code description:description underlyingError:nil];
+    return [self safeAssignError:error code:code description:description underlyingError:nil];
 }
 
-- (void)safeAssignError:(NSError **)error code:(MPNativePositionResponseDeserializationErrorCode)code description:(NSString *)description underlyingError:(NSError *)underlyingError
+- (BOOL)safeAssignError:(NSError **)error code:(MPNativePositionResponseDeserializationErrorCode)code description:(NSString *)description underlyingError:(NSError *)underlyingError
 {
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
 
@@ -237,7 +243,7 @@ static NSInteger const MPMaxRepeatingInterval = 1 << 16;
         [userInfo setObject:underlyingError forKey:NSUnderlyingErrorKey];
     }
 
-    [self safeAssignError:error code:code userInfo:userInfo];
+    return [self safeAssignError:error code:code userInfo:userInfo];
 }
 
 - (NSError *)deserializationErrorWithCode:(MPNativePositionResponseDeserializationErrorCode)code userInfo:(NSDictionary *)userInfo


### PR DESCRIPTION
In this commit I tried to address these issues:

1. Safer dealloc methods:
  * Added checks if some ad views or ad objects is already existed before allocating a new one. Also set their delegate to nil to prevent any calling to MoPub objects.
  * Added checks if objects is existed before setting their delegates to nil.

2. Remove Xcode 6.2's deprecated methods warnings.

3. Remove Xcode 6.2's analyze warnings: methods taking in `NSError **` must return BOOL to indicate whether it is successful.