### PR TITLE
Fix issues with ad loading

### DIFF
--- a/AdNetworkSupport/Vungle/MPVungleRouter.m
+++ b/AdNetworkSupport/Vungle/MPVungleRouter.m
@@ -68,7 +68,7 @@ static NSString *const kMPVungleAdUserDidDownloadKey = @"didDownload";
     });
 
     // Need to check immediately as an ad may be cached.
-    if ([[VungleSDK sharedSDK] isCachedAdAvailable]) {
+    if ([[VungleSDK sharedSDK] isAdPlayable]) {
         [self.delegate vungleAdDidLoad];
     }
 
@@ -77,7 +77,7 @@ static NSString *const kMPVungleAdUserDidDownloadKey = @"didDownload";
 
 - (BOOL)isAdAvailable
 {
-    return [[VungleSDK sharedSDK] isCachedAdAvailable];
+    return [[VungleSDK sharedSDK] isAdPlayable];
 }
 
 - (void)presentInterstitialAdFromViewController:(UIViewController *)viewController withDelegate:(id<MPVungleRouterDelegate>)delegate
@@ -137,9 +137,10 @@ static NSString *const kMPVungleAdUserDidDownloadKey = @"didDownload";
 
 #pragma mark - VungleSDKDelegate
 
-- (void)vungleSDKhasCachedAdAvailable
+- (void)vungleSDKAdPlayableChanged:(BOOL)isAdPlayable
 {
-    [self.delegate vungleAdDidLoad];
+	if (isAdPlayable)
+		[self.delegate vungleAdDidLoad];
 }
 
 - (void)vungleSDKwillShowAd

--- a/AdNetworkSupport/Vungle/VungleRewardedVideoCustomEvent.m
+++ b/AdNetworkSupport/Vungle/VungleRewardedVideoCustomEvent.m
@@ -31,7 +31,7 @@
 
 - (BOOL)hasAdAvailable
 {
-    return [[VungleSDK sharedSDK] isCachedAdAvailable];
+    return [[VungleSDK sharedSDK] isAdPlayable];
 }
 
 - (void)presentRewardedVideoFromViewController:(UIViewController *)viewController


### PR DESCRIPTION
Starting from Vungle SDK 3.2.0, delegate method
vungleSDKAdPlayableChanged is called when ad is ready to play, whereas
deprecated method vungleSDKhasCachedAdAvailable is called when ad is
loaded, but may not be ready to play yet.

The methods isAdPlayable and isCachedAdAvailable are the same, but the
second one is deprecated and will be removed soon.