### PR TITLE
Categories should be prefixed 

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdServerURLBuilder.m
+++ b/MoPubSDK/Internal/Common/MPAdServerURLBuilder.m
@@ -233,38 +233,38 @@ static NSInteger const kAdSequenceNone = -1;
 {
     NSString *applicationVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
     return [NSString stringWithFormat:@"&av=%@",
-            [applicationVersion URLEncodedString]];
+            [applicationVersion mp_URLEncodedString]];
 }
 
 + (NSString *)queryParameterForCarrierName
 {
     NSString *carrierName = [[[MPCoreInstanceProvider sharedProvider] sharedCarrierInfo] objectForKey:@"carrierName"];
     return carrierName ? [NSString stringWithFormat:@"&cn=%@",
-                          [carrierName URLEncodedString]] : @"";
+                          [carrierName mp_URLEncodedString]] : @"";
 }
 
 + (NSString *)queryParameterForISOCountryCode
 {
     NSString *code = [[[MPCoreInstanceProvider sharedProvider] sharedCarrierInfo] objectForKey:@"isoCountryCode"];
-    return code ? [NSString stringWithFormat:@"&iso=%@", [code URLEncodedString]] : @"";
+    return code ? [NSString stringWithFormat:@"&iso=%@", [code mp_URLEncodedString]] : @"";
 }
 
 + (NSString *)queryParameterForMobileNetworkCode
 {
     NSString *code = [[[MPCoreInstanceProvider sharedProvider] sharedCarrierInfo] objectForKey:@"mobileNetworkCode"];
-    return code ? [NSString stringWithFormat:@"&mnc=%@", [code URLEncodedString]] : @"";
+    return code ? [NSString stringWithFormat:@"&mnc=%@", [code mp_URLEncodedString]] : @"";
 }
 
 + (NSString *)queryParameterForMobileCountryCode
 {
     NSString *code = [[[MPCoreInstanceProvider sharedProvider] sharedCarrierInfo] objectForKey:@"mobileCountryCode"];
-    return code ? [NSString stringWithFormat:@"&mcc=%@", [code URLEncodedString]] : @"";
+    return code ? [NSString stringWithFormat:@"&mcc=%@", [code mp_URLEncodedString]] : @"";
 }
 
 + (NSString *)queryParameterForDeviceName
 {
-    NSString *deviceName = [[UIDevice currentDevice] hardwareDeviceName];
-    return deviceName ? [NSString stringWithFormat:@"&dn=%@", [deviceName URLEncodedString]] : @"";
+    NSString *deviceName = [[UIDevice currentDevice] mp_hardwareDeviceName];
+    return deviceName ? [NSString stringWithFormat:@"&dn=%@", [deviceName mp_URLEncodedString]] : @"";
 }
 
 + (NSString *)queryParameterForDesiredAdAssets:(NSArray *)assets
@@ -288,7 +288,7 @@ static NSInteger const kAdSequenceNone = -1;
 + (NSString *)queryParameterForBundleIdentifier
 {
     NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
-    return bundleIdentifier ? [NSString stringWithFormat:@"&bundle=%@", [bundleIdentifier URLEncodedString]] : @"";
+    return bundleIdentifier ? [NSString stringWithFormat:@"&bundle=%@", [bundleIdentifier mp_URLEncodedString]] : @"";
 }
 
 + (BOOL)advertisingTrackingEnabled

--- a/MoPubSDK/Internal/Event Logging/MPLogEventCommunicator.m
+++ b/MoPubSDK/Internal/Event Logging/MPLogEventCommunicator.m
@@ -86,7 +86,7 @@ static const NSInteger MAX_CONCURRENT_CONNECTIONS = 1;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:serializedEvents options:0 error:nil];
     
     NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    NSString *paramString = [NSString stringWithFormat:@"log=%@", [jsonString URLEncodedString]];
+    NSString *paramString = [NSString stringWithFormat:@"log=%@", [jsonString mp_URLEncodedString]];
     
     return paramString;
 }

--- a/MoPubSDK/Internal/HTML/MPAdWebViewAgent.m
+++ b/MoPubSDK/Internal/HTML/MPAdWebViewAgent.m
@@ -253,7 +253,7 @@
     if (self.configuration.clickTrackingURL) {
         NSString *path = [NSString stringWithFormat:@"%@&r=%@",
                           self.configuration.clickTrackingURL.absoluteString,
-                          [[URL absoluteString] URLEncodedString]];
+                          [[URL absoluteString] mp_URLEncodedString]];
         redirectedURL = [NSURL URLWithString:path];
     }
 

--- a/MoPubSDK/Internal/Utility/MPGlobal.h
+++ b/MoPubSDK/Internal/Utility/MPGlobal.h
@@ -72,7 +72,7 @@ typedef NSUInteger MPInterstitialOrientationType;
 /*
  * Returns string with reserved/unsafe characters encoded.
  */
-- (NSString *)URLEncodedString;
+- (NSString *)mp_URLEncodedString;
 
 @end
 
@@ -80,7 +80,7 @@ typedef NSUInteger MPInterstitialOrientationType;
 
 @interface UIDevice (MPAdditions)
 
-- (NSString *)hardwareDeviceName;
+- (NSString *)mp_hardwareDeviceName;
 
 @end
 

--- a/MoPubSDK/Internal/Utility/MPGlobal.m
+++ b/MoPubSDK/Internal/Utility/MPGlobal.m
@@ -189,7 +189,7 @@ NSString *MPResourcePathForResource(NSString *resourceName)
 
 @implementation NSString (MPAdditions)
 
-- (NSString *)URLEncodedString
+- (NSString *)mp_URLEncodedString
 {
     NSString *result = (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                            (CFStringRef)self,
@@ -205,7 +205,7 @@ NSString *MPResourcePathForResource(NSString *resourceName)
 
 @implementation UIDevice (MPAdditions)
 
-- (NSString *)hardwareDeviceName
+- (NSString *)mp_hardwareDeviceName
 {
     size_t size;
     sysctlbyname("hw.machine", NULL, &size, NULL, 0);

--- a/Specs/MoPubSDKSpecs/Internal/Common/MPAdServerURLBuilderSpec.mm
+++ b/Specs/MoPubSDKSpecs/Internal/Common/MPAdServerURLBuilderSpec.mm
@@ -309,7 +309,7 @@ describe(@"MPAdServerURLBuilder", ^{
                                            keywords:nil
                                            location:nil
                                             testing:YES];
-        URL.absoluteString should contain([NSString stringWithFormat:@"&dn=%@", [[[UIDevice currentDevice] hardwareDeviceName] URLEncodedString]]);
+        URL.absoluteString should contain([NSString stringWithFormat:@"&dn=%@", [[[UIDevice currentDevice] mp_hardwareDeviceName] mp_URLEncodedString]]);
     });
 
     it(@"should provide the screen size in pixels", ^{
@@ -325,7 +325,7 @@ describe(@"MPAdServerURLBuilder", ^{
     });
 
     it(@"should provide the app's bundle identifier", ^{
-        NSString *bundleParam = [NSString stringWithFormat:@"&bundle=%@", [[[NSBundle mainBundle] bundleIdentifier] URLEncodedString]];
+        NSString *bundleParam = [NSString stringWithFormat:@"&bundle=%@", [[[NSBundle mainBundle] bundleIdentifier] mp_URLEncodedString]];
 
         URL = [MPAdServerURLBuilder URLWithAdUnitID:@"guy"
                                            keywords:nil

--- a/Specs/MoPubSDKSpecs/Internal/Event Logging/MPLogEventCommunicatorSpec.mm
+++ b/Specs/MoPubSDKSpecs/Internal/Event Logging/MPLogEventCommunicatorSpec.mm
@@ -76,7 +76,7 @@ describe(@"MPLogEventCommunicator", ^{
             
             NSData *expectedJSON = [NSJSONSerialization dataWithJSONObject:@[[event asDictionary]] options:0 error:nil];
             NSString *expectedJSONString = [[NSString alloc] initWithData:expectedJSON encoding:NSUTF8StringEncoding];
-            NSString *expectedBodyString = [NSString stringWithFormat:@"log=%@", [expectedJSONString URLEncodedString]];
+            NSString *expectedBodyString = [NSString stringWithFormat:@"log=%@", [expectedJSONString mp_URLEncodedString]];
             request.HTTPBodyAsString should equal(expectedBodyString);
         });
         


### PR DESCRIPTION
Categories should be prefixed so they do not conflict with similar implementations, especially something as widely used as URLEncodedString