### PR TITLE
suppressed some warnings. possibly fixed one, too.

### DIFF
--- a/MoPubSDK/Internal/Common/MPActivityViewControllerHelper.m
+++ b/MoPubSDK/Internal/Common/MPActivityViewControllerHelper.m
@@ -76,6 +76,7 @@
             [[MPActivityItemProviderWithSubject alloc] initWithSubject:subject body:body];
         UIActivityViewController *activityViewController =
             [[UIActivityViewController alloc] initWithActivityItems:@[activityItemProvider] applicationActivities:nil];
+        #pragma GCC diagnostic ignored "-Wdeprecated"
         activityViewController.completionHandler = ^
             (NSString* activityType, BOOL completed) {
                 if ([self.delegate respondsToSelector:@selector(activityViewControllerDidDismiss)]) {

--- a/MoPubSDK/Internal/MPInstanceProvider.m
+++ b/MoPubSDK/Internal/MPInstanceProvider.m
@@ -157,6 +157,7 @@ static MPInstanceProvider *sharedAdProvider = nil;
         MPLogError(@"**** Custom Event Class: %@ does not extend MPInterstitialCustomEvent ****", NSStringFromClass(customClass));
         return nil;
     }
+    #pragma GCC diagnostic ignored "-Wundeclared-selector"
     if ([customEvent respondsToSelector:@selector(customEventDidUnload)]) {
         MPLogWarn(@"**** Custom Event Class: %@ implements the deprecated -customEventDidUnload method.  This is no longer called.  Use -dealloc for cleanup instead ****", NSStringFromClass(customClass));
     }

--- a/MoPubSDK/Internal/Utility/MPGeolocationProvider.m
+++ b/MoPubSDK/Internal/Utility/MPGeolocationProvider.m
@@ -252,7 +252,7 @@ const NSTimeInterval kMPLocationUpdateInterval = 10.0 * 60.0;
         case kCLAuthorizationStatusRestricted:
             self.authorizedForLocationServices = NO;
             break;
-        case kCLAuthorizationStatusAuthorized: // same as kCLAuthorizationStatusAuthorizedAlways
+        case kCLAuthorizationStatusAuthorizedAlways:
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
         case kCLAuthorizationStatusAuthorizedWhenInUse:
 #endif

--- a/MoPubSDK/MoPub.m
+++ b/MoPubSDK/MoPub.m
@@ -67,6 +67,7 @@
 - (void)initializeRewardedVideoWithGlobalMediationSettings:(NSArray *)globalMediationSettings delegate:(id<MPRewardedVideoDelegate>)delegate
 {
     // initializeWithDelegate: is a known private initialization method on MPRewardedVideo. So we forward the initialization call to that class.
+    #pragma GCC diagnostic ignored "-Wundeclared-selector"
     [MPRewardedVideo performSelector:@selector(initializeWithDelegate:) withObject:delegate];
     self.globalMediationSettings = globalMediationSettings;
 }


### PR DESCRIPTION
The following changes were made to get the code to build when warnings
are treated as errors and the source is included directly in the project:

- Suppressed most of the warnings that prevent the code from building
  when including the source directly in the project

- Made a single change that should update one of the deprecated switch
  cases from a deprecated value to a non-deprecated value to remove the
  warning.