### PR TITLE
fixed ad load crashes

### DIFF
--- a/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
@@ -104,6 +104,11 @@ static NSString * const kCollectionViewAdPlacerReuseIdentifier = @"MPCollectionV
 
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didLoadAdAtIndexPath:(NSIndexPath *)indexPath
 {
+    if (!(indexPath.section<[self.collectionView numberOfSections] &&
+          indexPath.row<[self.collectionView numberOfItemsInSection:indexPath.section])) {
+            return;
+    }
+    
     BOOL animationsWereEnabled = [UIView areAnimationsEnabled];
     //We only want to enable animations if the index path is before or within our visible cells
     BOOL animationsEnabled = ([(NSIndexPath *)[self.collectionView.indexPathsForVisibleItems lastObject] compare:indexPath] != NSOrderedAscending) && animationsWereEnabled;

--- a/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
@@ -104,6 +104,11 @@ static NSString * const kTableViewAdPlacerReuseIdentifier = @"MPTableViewAdPlace
 
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didLoadAdAtIndexPath:(NSIndexPath *)indexPath
 {
+    if (!(indexPath.section<[self.tableView numberOfSections] &&
+        indexPath.row<[self.tableView numberOfRowsInSection:indexPath.section])) {
+            return;
+    }
+    
     BOOL originalAnimationsEnabled = [UIView areAnimationsEnabled];
     //We only want to enable animations if the index path is before or within our visible cells
     BOOL animationsEnabled = ([(NSIndexPath *)[self.tableView.indexPathsForVisibleRows lastObject] compare:indexPath] != NSOrderedAscending) && originalAnimationsEnabled;


### PR DESCRIPTION
Hi there! 
I have many crashes in slow internet connections when native ads are loading. 
Trace from Fabric: http://crashes.to/s/25df162872d

It was already suggested here https://github.com/justadreamer/mopub-ios-sdk/commit/1d5994507fbb31083d45001f0ab2c948b8fde3e9