### PR TITLE
Fixes Crash when tapping on the Ad

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdBrowserController.m
+++ b/MoPubSDK/Internal/Common/MPAdBrowserController.m
@@ -51,7 +51,7 @@ static NSString * const kAdBrowserControllerNibName = @"MPAdBrowserController";
 
 - (id)initWithURL:(NSURL *)URL HTMLString:(NSString *)HTMLString delegate:(id<MPAdBrowserControllerDelegate>)delegate
 {
-    if (self = [super initWithNibName:MPResourcePathForResource(kAdBrowserControllerNibName) bundle:nil]) {
+    if (self = [super initWithNibName:MPResourcePathForResource(kAdBrowserControllerNibName) bundle:[NSBundle bundleForClass:[MPAdBrowserController class]]]) {
         self.delegate = delegate;
         self.URL = URL;
         self.HTMLString = HTMLString;


### PR DESCRIPTION
`When` user Taps on an Ad 
`Then` app crash
The error is 
`Could not load NIB in bundle: 'NSBundle </var/mobile/Containers/Bundle/Application/xxx/xxxxx.app> (loaded)' with name 'MPAdBrowserController'`

The current code tries to load the View Nib from the a wrong Bundle (mainBundle)