### PR TITLE
Tapjoy SDK 11.7 Update

### DIFF
--- a/AdNetworkSupport/TapJoy/TapjoyInterstitialCustomEvent.h
+++ b/AdNetworkSupport/TapJoy/TapjoyInterstitialCustomEvent.h
@@ -6,7 +6,7 @@
 #endif
 
 /*
- * Certified with version 11.5.1 of the Tapjoy SDK.
+ * Certified with version 11.7.0 of the Tapjoy SDK.
  */
 
 @interface TapjoyInterstitialCustomEvent : MPInterstitialCustomEvent

--- a/AdNetworkSupport/TapJoy/TapjoyRewardedVideoCustomEvent.h
+++ b/AdNetworkSupport/TapJoy/TapjoyRewardedVideoCustomEvent.h
@@ -6,7 +6,7 @@
 #endif
 
 /*
- * Certified with version 11.5.1 of the Tapjoy SDK.
+ * Certified with version 11.7.0 of the Tapjoy SDK.
  */
 
 @interface TapjoyRewardedVideoCustomEvent : MPRewardedVideoCustomEvent

--- a/AdNetworkSupport/TapJoy/TapjoyRewardedVideoCustomEvent.m
+++ b/AdNetworkSupport/TapJoy/TapjoyRewardedVideoCustomEvent.m
@@ -1,8 +1,7 @@
 
 #import "TapjoyRewardedVideoCustomEvent.h"
-
-#import <Tapjoy/TJPlacement.h>
 #import <Tapjoy/Tapjoy.h>
+#import <Tapjoy/TJPlacement.h>
 #import "MPRewardedVideoError.h"
 #import "MPLogging.h"
 #import "MPRewardedVideoReward.h"
@@ -11,27 +10,84 @@
 
 @interface TapjoyRewardedVideoCustomEvent () <TJPlacementDelegate, TJCVideoAdDelegate>
 @property (nonatomic, strong) TJPlacement *placement;
+@property (nonatomic, assign) BOOL isAutoConnect;
+@property (nonatomic, strong) NSString *placementName;
 @end
 
 @implementation TapjoyRewardedVideoCustomEvent
 
-- (void)requestRewardedVideoWithCustomEventInfo:(NSDictionary *)info
-{
-    MPLogInfo(@"Requesting Tapjoy rewarded video");
+- (void)setupListeners{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(tjcConnectSuccess:)
+                                                 name:TJC_CONNECT_SUCCESS
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(tjcConnectFail:)
+                                                 name:TJC_CONNECT_FAILED
+                                               object:nil];
+}
+- (void)initializeWithCustomNetworkInfo:(NSDictionary *)info {
     //Instantiate Mediation Settings
     TapjoyGlobalMediationSettings *medSettings = [[MoPub sharedInstance] globalMediationSettingsForClass:[TapjoyGlobalMediationSettings class]];
-
-    if (![Tapjoy isConnected]) {
+    
+    
+    // Grab sdkKey and connect flags defined in MoPub dashboard
+    NSString *sdkKey = info[@"sdkKey"];
+    BOOL enableDebug = info[@"debugEnabled"];
+    
+    
+    _isAutoConnect = NO;
+    
+    if (medSettings.sdkKey) {
+        MPLogInfo(@"Connecting to Tapjoy via MoPub mediation settings");
+        [self setupListeners];
         [Tapjoy connect:medSettings.sdkKey
                 options:medSettings.connectFlags];
+        
+        _isAutoConnect = YES;
+        
+    } else if (sdkKey) {
+        MPLogInfo(@"Connecting to Tapjoy via MoPub dashboard settings");
+        NSMutableDictionary *connectOptions = [[NSMutableDictionary alloc] init];
+        [connectOptions setObject:@(enableDebug) forKey:TJC_OPTION_ENABLE_LOGGING];
+        [self setupListeners];
+        
+        [Tapjoy connect:sdkKey
+                options:connectOptions];
+        
+        _isAutoConnect = YES;
+        
+    } else {
+        MPLogInfo(@"Tapjoy rewarded video is initialized with empty 'sdkKey'. You must call Tapjoy connect before requesting content.");
+        [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:nil];
     }
+}
+
+- (void)requestRewardedVideoWithCustomEventInfo:(NSDictionary *)info
+{
     // Grab placement name defined in MoPub dashboard as custom event data
-    NSString *name = info[@"name"];
+    _placementName = info[@"name"];
+    
+    if (![Tapjoy isConnected]) {
+        if (_isAutoConnect) {
+            //Adapter is making connect call on behalf of publisher, wait for success before requesting content
+            return;
+        } else {
+            [self initializeWithCustomNetworkInfo:info];
+        }
+    } else {
+        //Tapjoy has successfully connected
+        MPLogInfo(@"Requesting Tapjoy rewarded video");
+        [self requestPlacementContent];
+    }
+}
 
-    if(name) {
-        _placement = [TJPlacement placementWithName:name mediationAgent:@"mopub" mediationId:nil delegate:self];
-        _placement.adapterVersion = @"3.0";
-
+- (void)requestPlacementContent {
+    if(_placementName) {
+        _placement = [TJPlacement placementWithName:_placementName mediationAgent:@"mopub" mediationId:nil delegate:self];
+        _placement.adapterVersion = @"4.1.0";
+        
         [_placement requestContent];
     }
     else {
@@ -40,7 +96,6 @@
         [self.delegate rewardedVideoDidFailToLoadAdForCustomEvent:self error:error];
     }
 }
-
 - (void)presentRewardedVideoFromViewController:(UIViewController *)viewController
 {
     if ([self hasAdAvailable]) {
@@ -52,7 +107,7 @@
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:nil];
         [self.delegate rewardedVideoDidFailToPlayForCustomEvent:self error:error];
     }
-
+    
 }
 
 - (BOOL)hasAdAvailable
@@ -117,6 +172,22 @@
 - (void)videoAdCompleted {
     MPLogInfo(@"Tapjoy rewarded video completed");
     [self.delegate rewardedVideoShouldRewardUserForCustomEvent:self reward:[[MPRewardedVideoReward alloc] initWithCurrencyAmount:@(kMPRewardedVideoRewardCurrencyAmountUnspecified)]];
+}
+
+-(void)tjcConnectSuccess:(NSNotification*)notifyObj
+{
+    MPLogInfo(@"Tapjoy connect Succeeded");
+    _isAutoConnect = NO;
+    [self requestPlacementContent];
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:TJC_CONNECT_SUCCESS object:nil];
+}
+
+- (void)tjcConnectFail:(NSNotification*)notifyObj
+{
+    MPLogInfo(@"Tapjoy connect Failed");
+    _isAutoConnect = NO;
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:TJC_CONNECT_FAILED object:nil];
 }
 
 


### PR DESCRIPTION
Update for Tapjoy 11.7 SDK:
- Enable Tapjoy auto-connect when `sdkKey` is defined in the MoPub dashboard 

**Previously:**
Publishers were responsible for calling `[Tapjoy connect: 'publisher_sdkKey']` directly before making content requests to MoPub.

**New:**
Publishers can now define Tapjoy connect params (e.g. sdkKey, debugEnabled) in MoPub’s dashboard. When a request is made to MoPub, the adapter will handle the connect call using the connect params defined before requesting content.

Publishers can enter these params via the `CUSTOM EVENT CLASS DATA` box. 
For example:

```
{
"sdkKey":"enter_publisher_api_key_here",
 "name": "video_unit",
 "debugEnabled":"YES"
}
```
