### PR TITLE
Replace usages of typeof with __typeof

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdDestinationDisplayAgent.m
+++ b/MoPubSDK/Internal/Common/MPAdDestinationDisplayAgent.m
@@ -88,9 +88,9 @@ static NSString * const kDisplayAgentErrorDomain = @"com.mopub.displayagent";
     [self.resolver cancel];
     [self.enhancedDeeplinkFallbackResolver cancel];
 
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof(self) weakSelf = self;
     self.resolver = [[MPCoreInstanceProvider sharedProvider] buildMPURLResolverWithURL:URL completion:^(MPURLActionInfo *suggestedAction, NSError *error) {
-        typeof(self) strongSelf = weakSelf;
+        __typeof(self) strongSelf = weakSelf;
         if (strongSelf) {
             if (error) {
                 [strongSelf failedToResolveURLWithError:error];
@@ -176,10 +176,10 @@ static NSString * const kDisplayAgentErrorDomain = @"com.mopub.displayagent";
 
 - (void)handleEnhancedDeeplinkFallbackForRequest:(MPEnhancedDeeplinkRequest *)request;
 {
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof(self) weakSelf = self;
     [self.enhancedDeeplinkFallbackResolver cancel];
     self.enhancedDeeplinkFallbackResolver = [[MPCoreInstanceProvider sharedProvider] buildMPURLResolverWithURL:request.fallbackURL completion:^(MPURLActionInfo *actionInfo, NSError *error) {
-        typeof(self) strongSelf = weakSelf;
+        __typeof(self) strongSelf = weakSelf;
         if (strongSelf) {
             if (error) {
                 // If the resolver fails, just treat the entire original URL as a regular deeplink.

--- a/MoPubSDK/Native Ads/Internal/MPNativeAdRendererImageHandler.m
+++ b/MoPubSDK/Native Ads/Internal/MPNativeAdRendererImageHandler.m
@@ -59,10 +59,10 @@
         } else if (imageURL) {
             MPLogDebug(@"Cache miss on %@. Re-downloading...", imageURL);
 
-            __weak typeof(self) weakSelf = self;
+            __weak __typeof(self) weakSelf = self;
             [self.imageDownloadQueue addDownloadImageURLs:@[imageURL]
                                           completionBlock:^(NSArray *errors) {
-                                              __strong typeof(self) strongSelf = weakSelf;
+                                              __strong __typeof(self) strongSelf = weakSelf;
                                               if (strongSelf) {
                                                   if (errors.count == 0) {
                                                       UIImage *image = [UIImage imageWithData:[[MPNativeCache sharedCache] retrieveDataForKey:imageURL.absoluteString]];

--- a/MoPubSDK/NativeVideo/Internal/MOPUBPlayerView.m
+++ b/MoPubSDK/NativeVideo/Internal/MOPUBPlayerView.m
@@ -130,9 +130,9 @@ static CGFloat const kGradientViewHeight = 25.0f;
 {
     if (!self.replayView) {
         self.replayView = [[MOPUBReplayView alloc] initWithFrame:self.avView.bounds displayMode:self.displayMode];
-        __weak typeof(self) weakSelf = self;
+        __weak __typeof(self) weakSelf = self;
         self.replayView.actionBlock = ^(MOPUBReplayView *view) {
-            __strong typeof(self) strongSelf = weakSelf;
+            __strong __typeof(self) strongSelf = weakSelf;
             if ([strongSelf.delegate respondsToSelector:@selector(playerViewDidTapReplayButton:)]) {
                 [strongSelf.delegate playerViewDidTapReplayButton:strongSelf];
             }


### PR DESCRIPTION
* typeof is only valid with GNU99
  * http://stackoverflow.com/questions/31919577/typeof-does-not-work-and-throws-error-while-compiling
  * GNU99 is the default dialect for new Xcode projects, but some developers are using more modern ones like C11
* This change provides complete compatibility with C11 based on building the SDK