### PR TITLE
Fix ad loading while the user is scrolling

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdServerCommunicator.m
+++ b/MoPubSDK/Internal/Common/MPAdServerCommunicator.m
@@ -68,8 +68,14 @@ const NSTimeInterval kRequestTimeoutInterval = 10.0;
     self.adRequestLatencyEvent = [[MPLogEvent alloc] initWithEventCategory:MPLogEventCategoryRequests eventName:MPLogEventNameAdRequest];
     self.adRequestLatencyEvent.requestURI = URL.absoluteString;
 
-    self.connection = [NSURLConnection connectionWithRequest:[self adRequestForURL:URL]
-                                                    delegate:self];
+    self.connection = [[NSURLConnection alloc] initWithRequest:[self adRequestForURL:URL]
+                                                      delegate:self
+                                              startImmediately:NO];
+    
+    // Allow ads to load during scrolling by changing the run loop mode.
+    [self.connection scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    [self.connection start];
+    
     self.loading = YES;
 }
 


### PR DESCRIPTION
See also #167. Much like the Timer issue, when an NSURLConnection is created without specifying run loop modes, it defaults to `NSDefaultRunLoopMode`. Since this does not fire during `UITrackingRunLoopMode` it will not call the delegate, which prevents ads from loading.

This fix allows the delegates to fire during scrolling, which in turn allows ads to load.