### PR TITLE
Do not allow ads to open themselves

### DIFF
--- a/MoPubSDK/Internal/HTML/MPAdWebViewAgent.m
+++ b/MoPubSDK/Internal/HTML/MPAdWebViewAgent.m
@@ -206,7 +206,12 @@
         [self performActionForMoPubSpecificURL:URL];
         return NO;
     } else if ([self shouldIntercept:URL navigationType:navigationType]) {
-        [self interceptURL:URL];
+        if (self.userInteractedWithWebView) {
+            [self interceptURL:URL];
+        } else {
+            MPLogWarn(@"Attempted to load URL without user interaction: %@", request);
+        }
+        
         return NO;
     } else {
         // don't handle any deep links without user interaction


### PR DESCRIPTION
When URLs are allowed to be intercepted when the user hasn’t interacted, ads are allowed and able to launch themselves, triggering their e.g. open App Store behavior.

This prevents the interception and logs when an ad is detected. An example log looks like:

```
MOPUB: Attempted to load URL without user interaction: <NSMutableURLRequest: 0x17020f9d0> { URL: http://polimerk.com/… }
```