### PR TITLE
Don't allow audio ads to play automatically

### DIFF
--- a/MoPubSDK/Internal/HTML/MPWebView.m
+++ b/MoPubSDK/Internal/HTML/MPWebView.m
@@ -69,7 +69,9 @@ static NSString *const kMoPubFrameKeyPathString = @"frame";
         WKUserContentController *contentController = [[WKUserContentController alloc] init];
         WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
         config.allowsInlineMediaPlayback = kMoPubAllowsInlineMediaPlaybackDefault;
-        if ([config respondsToSelector:@selector(requiresUserActionForMediaPlayback)]) {
+        if ([config respondsToSelector:@selector(mediaTypesRequiringUserActionForPlayback)]) {
+            config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeAudio;
+        } else if ([config respondsToSelector:@selector(requiresUserActionForMediaPlayback)]) {
             config.requiresUserActionForMediaPlayback = kMoPubRequiresUserActionForMediaPlaybackDefault;
         } else {
             config.mediaPlaybackRequiresUserAction = kMoPubRequiresUserActionForMediaPlaybackDefault;


### PR DESCRIPTION
On iOS 10, when `requiresUserActionForMediaPlayback` is set to `false`, the `mediaTypesRequiringUserActionForPlayback` (which is a new property on iOS 10) is set to allow all media types.

The result is that audio ads are able to be played without user interaction, including annoying mp3s and videos alike. This prevents the audio ads by requiring audio be tapped on.