### PR TITLE
Fix to unspecified currency type string check in MPRewardedVideoAdapter

### DIFF
--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdapter.m
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdapter.m
@@ -268,7 +268,7 @@ static const NSString *kRewardedVideoApiVersion = @"1";
 
         // If reward is set in adConfig, use reward that's set in adConfig.
         // Currency type has to be defined in mopubConfiguredReward in order to use mopubConfiguredReward.
-        if (mopubConfiguredReward && mopubConfiguredReward.currencyType != kMPRewardedVideoRewardCurrencyTypeUnspecified) {
+        if (mopubConfiguredReward && ![mopubConfiguredReward.currencyType isEqualToString:kMPRewardedVideoRewardCurrencyTypeUnspecified]) {
             reward = mopubConfiguredReward;
         }
     }


### PR DESCRIPTION
In -rewardedVideoShouldRewardUserForCustomEvent:reward:, a check for unspecified currency type is done comparing a string constant and a string property with a "!=". This check should be done with the -isEqualToString: method instead.