### PR TITLE
Unity SDK 2.1.0 support and backwards compatibility.

### DIFF
--- a/AdNetworkSupport/Unity/MPUnityRouter.h
+++ b/AdNetworkSupport/Unity/MPUnityRouter.h
@@ -15,6 +15,8 @@
 @interface MPUnityRouter : NSObject <UnityAdsExtendedDelegate>
 
 @property (nonatomic, weak) id<MPUnityRouterDelegate> delegate;
+@property NSMutableDictionary* delegateMap;
+@property NSString* currentPlacementId;
 
 + (MPUnityRouter *)sharedRouter;
 
@@ -32,7 +34,9 @@
 - (void)unityAdsDidStart:(NSString *)placementId;
 - (void)unityAdsDidFinish:(NSString *)placementId withFinishState:(UnityAdsFinishState)state;
 - (void)unityAdsDidClick:(NSString *)placementId;
-
 - (void)unityAdsDidFailWithError:(NSError *)error;
+
+@optional
+- (void)unityAdsPlacementStateChanged:(NSString*)placementId oldState:(UnityAdsPlacementState)oldState newState:(UnityAdsPlacementState)newState;
 
 @end

--- a/AdNetworkSupport/Unity/UnityAdsInterstitialCustomEvent.m
+++ b/AdNetworkSupport/Unity/UnityAdsInterstitialCustomEvent.m
@@ -16,6 +16,7 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 
 @interface UnityAdsInterstitialCustomEvent () <MPUnityRouterDelegate>
 
+@property BOOL loadRequested;
 @property (nonatomic, copy) NSString *placementId;
 
 @end
@@ -27,8 +28,8 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
     [[MPUnityRouter sharedRouter] clearDelegate:self];
 }
 
-- (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info
-{
+- (void)requestInterstitialWithCustomEventInfo:(NSDictionary *)info {
+    self.loadRequested = YES;
     NSString *gameId = [info objectForKey:kMPUnityRewardedVideoGameId];
     self.placementId = [info objectForKey:kUnityAdsOptionPlacementIdKey];
     if (self.placementId == nil) {
@@ -74,7 +75,10 @@ static NSString *const kUnityAdsOptionZoneIdKey = @"zoneId";
 
 - (void)unityAdsReady:(NSString *)placementId
 {
-    [self.delegate interstitialCustomEvent:self didLoadAd:placementId];
+    if (self.loadRequested) {
+        [self.delegate interstitialCustomEvent:self didLoadAd:placementId];
+        self.loadRequested = NO;
+    }
 }
 
 - (void)unityAdsDidError:(UnityAdsError)error withMessage:(NSString *)message


### PR DESCRIPTION
 - Ads delegation pattern
    This alleviates any race condition issues we may run into in the future.
    If the user loads multiple ads, it's unclear which delegate gets called,
    and the previous delegates are lost.

 - Retains the last placement ID for the unityAdsDidError callback

    In the future, unityAdsDidError should pass in the placement ID so that
    delegation can happen per the usual flow.

 - Guard against sending the UnityAdsReady message if an ad is playing

    This fixes the issue MoPub is seeing with an infinite loop cycle when an
    ad is dismissed.

 - Etc.
    Remove unecessary comments
    Prevents ready being dispatched more than once