### PR TITLE
Update Facebook adaptor with non whitespace clickable policy

### DIFF
--- a/AdNetworkSupport/Facebook/FacebookNativeAdAdapter.m
+++ b/AdNetworkSupport/Facebook/FacebookNativeAdAdapter.m
@@ -112,6 +112,10 @@ NSString *const kFBVideoAdsEnabledKey = @"video_enabled";
     [self.fbNativeAd registerViewForInteraction:view withViewController:[self.delegate viewControllerForPresentingModalView]];
 }
 
+- (void)willAttachToView:(UIView *)view withClickableViews:(NSArray *)clickableViews {
+    [self.fbNativeAd registerViewForInteraction:view withViewController:[self.delegate viewControllerForPresentingModalView] withClickableViews:clickableViews];
+}
+
 - (UIView *)privacyInformationIconView
 {
     return self.adChoicesView;

--- a/MoPubSDK/Native Ads/MPNativeAd.m
+++ b/MoPubSDK/Native Ads/MPNativeAd.m
@@ -85,7 +85,7 @@
 
     if (adView) {
         if (!self.hasAttachedToView) {
-            [self willAttachToView:self.associatedView];
+            [self willAttachToView:self.associatedView withClickableViews:adView.subviews];
             self.hasAttachedToView = YES;
         }
 
@@ -154,6 +154,15 @@
 - (void)willAttachToView:(UIView *)view
 {
     if ([self.adAdapter respondsToSelector:@selector(willAttachToView:)]) {
+        [self.adAdapter willAttachToView:view];
+    }
+}
+
+- (void)willAttachToView:(UIView *)view withClickableViews:(NSArray *)clickableViews
+{
+    if ([self.adAdapter respondsToSelector:@selector(willAttachToView:withClickableViews:)]) {
+        [self.adAdapter willAttachToView:view withClickableViews:clickableViews];
+    } else {
         [self.adAdapter willAttachToView:view];
     }
 }

--- a/MoPubSDK/Native Ads/MPNativeAdAdapter.h
+++ b/MoPubSDK/Native Ads/MPNativeAdAdapter.h
@@ -160,6 +160,17 @@
 - (void)willAttachToView:(UIView *)view;
 
 /**
+ * This method will be called when your ad's content is about to be loaded into a view with clickable views.
+ *
+ * @param view A view that will contain the ad content.
+ * @param clickableViews Array of views that contain clickable ad contents
+ 
+ * You should implement this method if the underlying third-party ad object needs to be informed
+ * of this event.
+ */
+- (void)willAttachToView:(UIView *)view withClickableViews:(NSArray *)clickableViews;
+
+/**
  * This method will be called if your implementation provides a DAA icon through the properties dictionary
  * and the user has tapped the icon.
  */


### PR DESCRIPTION
This diff is to update the Facebook Native Ad Adaptor to comply with clickable areas policy.
This is a short term solution fix which adds the following API to MPNativeAdAdapter.  This will be called by MPNativeAd when attach associatedView.

willAttachToView:(UIView *)view withClickableViews:(NSArray *)clickableViews


More info about the clickable ares policy.
https://developers.facebook.com/docs/audience-network/guidelines/native-ads

"Clickable Areas

In order to avoid potential accidental clicks, ensure that when implementing native ads only the advertiser assets are clickable. This means that the background of the ad must not be clickable, including if you use the ad image as a background (ex: no clickable “whitespace”)."

