### PR TITLE
Allow passing local extra data from view controllers to custom event delegates.

### DIFF
--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -234,6 +234,8 @@
         [self loadAdWithURL:self.requestingConfiguration.failoverURL];
         return;
     }
+    
+    self.requestingAdapter.networkExtras = self.banner.networkExtras;
 
     [self.requestingAdapter _getAdWithConfiguration:configuration containerSize:self.delegate.containerSize];
 }

--- a/MoPubSDK/Internal/Banners/MPBannerCustomEventAdapter.m
+++ b/MoPubSDK/Internal/Banners/MPBannerCustomEventAdapter.m
@@ -138,4 +138,9 @@
     }
 }
 
+- (NSDictionary *)getNetworkExtras
+{
+    return self.networkExtras;
+}
+
 @end

--- a/MoPubSDK/Internal/Banners/MPBaseBannerAdapter.h
+++ b/MoPubSDK/Internal/Banners/MPBaseBannerAdapter.h
@@ -21,6 +21,7 @@
 @property (nonatomic, weak) id<MPBannerAdapterDelegate> delegate;
 @property (nonatomic, copy) NSURL *impressionTrackingURL;
 @property (nonatomic, copy) NSURL *clickTrackingURL;
+@property (nonatomic, copy) NSDictionary * networkExtras;
 
 - (id)initWithDelegate:(id<MPBannerAdapterDelegate>)delegate;
 

--- a/MoPubSDK/Internal/Interstitials/MPBaseInterstitialAdapter.h
+++ b/MoPubSDK/Internal/Interstitials/MPBaseInterstitialAdapter.h
@@ -17,6 +17,8 @@
 
 @property (nonatomic, weak) id<MPInterstitialAdapterDelegate> delegate;
 
+@property (nonatomic, copy) NSDictionary * networkExtras;
+
 /*
  * Creates an adapter with a reference to an MPInterstitialAdManager.
  */

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
@@ -172,6 +172,9 @@
         [self adapter:nil didFailToLoadAdWithError:nil];
         return;
     }
+    
+    // Pass the network extras to the adapter.
+    adapter.networkExtras = self.interstitialAdController.networkExtras;
 
     self.adapter = adapter;
     [self.adapter _getAdWithConfiguration:configuration];

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialCustomEventAdapter.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialCustomEventAdapter.m
@@ -161,4 +161,9 @@
     [self.expirationTimer invalidate];
 }
 
+- (NSDictionary *)getNetworkExtras
+{
+    return self.networkExtras;
+}
+
 @end

--- a/MoPubSDK/MPAdView.h
+++ b/MoPubSDK/MPAdView.h
@@ -86,6 +86,11 @@ typedef enum
  */
 @property (nonatomic, assign, getter = isTesting) BOOL testing;
 
+/**
+ * A dictionary containing extra network data for the network event.
+ */
+@property (nonatomic, copy) NSDictionary * networkExtras;
+
 /** @name Loading a Banner Ad */
 
 /**

--- a/MoPubSDK/MPAdView.m
+++ b/MoPubSDK/MPAdView.m
@@ -32,6 +32,7 @@
 @synthesize testing = _testing;
 @synthesize adContentView = _adContentView;
 @synthesize allowedNativeAdOrientation = _allowedNativeAdOrientation;
+@synthesize networkExtras = _networkExtras;
 
 #pragma mark -
 #pragma mark Lifecycle

--- a/MoPubSDK/MPBannerCustomEventDelegate.h
+++ b/MoPubSDK/MPBannerCustomEventDelegate.h
@@ -132,4 +132,9 @@
  */
 - (void)trackClick;
 
+/**
+ * Get the network extra data set by the original client adapter.
+ */
+- (NSDictionary *)getNetworkExtras;
+
 @end

--- a/MoPubSDK/MPInterstitialAdController.h
+++ b/MoPubSDK/MPInterstitialAdController.h
@@ -81,6 +81,11 @@
  */
 @property (nonatomic, assign, getter=isTesting) BOOL testing;
 
+/**
+ * A dictionary containing network extra data for the custom network events.
+ */
+@property (nonatomic, copy) NSDictionary * networkExtras;
+
 /** @name Loading an Interstitial Ad */
 
 /**

--- a/MoPubSDK/MPInterstitialAdController.m
+++ b/MoPubSDK/MPInterstitialAdController.m
@@ -29,6 +29,7 @@
 @synthesize keywords = _keywords;
 @synthesize location = _location;
 @synthesize testing = _testing;
+@synthesize networkExtras = _networkExtras;
 
 - (id)initWithAdUnitId:(NSString *)adUnitId
 {

--- a/MoPubSDK/MPInterstitialCustomEventDelegate.h
+++ b/MoPubSDK/MPInterstitialCustomEventDelegate.h
@@ -180,4 +180,9 @@
  */
 - (void)trackClick;
 
+/**
+ * Get the network extra data set by the original client adapter.
+ */
+- (NSDictionary *)getNetworkExtras;
+
 @end


### PR DESCRIPTION
This request is similar to the functionality that is already provided in mopub-android-sdk:
https://github.com/mopub/mopub-android-sdk/wiki/Custom-Events#passing-extra-data-to-custom-events