### PR TITLE
Fix for uncaught NSInvalidArgumentException

### DIFF
--- a/AdNetworkSupport/GoogleAdMob/MPGoogleAdMobNativeRenderer.m
+++ b/AdNetworkSupport/GoogleAdMob/MPGoogleAdMobNativeRenderer.m
@@ -71,7 +71,7 @@
 /// Returns an ad view rendered using provided |adapter|. Sets an |error| if any error is
 /// encountered.
 - (UIView *)retrieveViewWithAdapter:(id<MPNativeAdAdapter>)adapter error:(NSError **)error {
-  if (!adapter) {
+  if (!adapter || ![adapter isKindOfClass:[MPGoogleAdMobNativeAdAdapter class]]) {
     if (error) {
       *error = MPNativeAdNSErrorForRenderValueTypeError();
     }


### PR DESCRIPTION
Adds an additional check to prevent a crash in MPGoogleAdMobNativeRenderer.m caused by:

reason: '-[MPMoPubNativeAdAdapter adMobNativeAppInstallAd]:
unrecognized selector sent to instance