### PR TITLE
Allow insert in collection or tableview without offsetting ads

### DIFF
--- a/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.h
+++ b/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.h
@@ -185,6 +185,16 @@
 - (void)mp_insertItemsAtIndexPaths:(NSArray *)indexPaths;
 
 /**
+ * Inserts new items at the specified index paths, and informs the attached ad placer of the
+ * insertions.
+ *
+ * @param indexPaths An array of `NSIndexPath` objects, each of which contains a section index and
+ * @param offsetAds If true, ads will be offseted when items are inserted. Otherwise, ads wont  move.
+ * item index at which to insert a new cell. This parameter must not be `nil`.
+ */
+- (void)mp_insertItemsAtIndexPaths:(NSArray *)indexPaths offsetAds:(Boolean)offsetAds;
+
+/**
  * Deletes the items at the specified index paths, and informs the attached ad placer of the
  * deletions.
  *

--- a/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPCollectionViewAdPlacer.m
@@ -60,8 +60,10 @@ static NSString * const kCollectionViewAdPlacerReuseIdentifier = @"MPCollectionV
         [_insertionTimer scheduleNow];
 
         _originalDataSource = collectionView.dataSource;
+        _originalPrefetchDataSource = collectionView.prefetchDataSource;
         _originalDelegate = collectionView.delegate;
         collectionView.dataSource = self;
+        collectionView.prefetchDataSource = self;
         collectionView.delegate = self;
 
         [_collectionView registerClass:[MPCollectionViewAdPlacerCell class] forCellWithReuseIdentifier:kCollectionViewAdPlacerReuseIdentifier];
@@ -582,11 +584,16 @@ static char kAdPlacerKey;
 
 - (void)mp_insertItemsAtIndexPaths:(NSArray *)indexPaths
 {
+    [self mp_insertItemsAtIndexPaths:indexPaths offsetAds:true];
+}
+
+- (void)mp_insertItemsAtIndexPaths:(NSArray *)indexPaths offsetAds:(Boolean)offsetAds
+{
     MPCollectionViewAdPlacer *adPlacer = [self mp_adPlacer];
     NSArray *adjustedIndexPaths = indexPaths;
 
     if (adPlacer) {
-        [adPlacer.streamAdPlacer insertItemsAtIndexPaths:indexPaths];
+        [adPlacer.streamAdPlacer insertItemsAtIndexPaths:indexPaths offsetAds:offsetAds];
         adjustedIndexPaths = [adPlacer.streamAdPlacer adjustedIndexPathsForOriginalIndexPaths:indexPaths];
     }
 

--- a/MoPubSDK/Native Ads/MPStreamAdPlacementData.h
+++ b/MoPubSDK/Native Ads/MPStreamAdPlacementData.h
@@ -29,6 +29,7 @@
 - (void)deleteSections:(NSIndexSet *)sections;
 - (void)moveSection:(NSInteger)section toSection:(NSInteger)newSection;
 - (void)insertItemsAtIndexPaths:(NSArray *)originalIndexPaths;
+- (void)insertItemsAtIndexPaths:(NSArray *)originalIndexPaths offsetAds:(Boolean)offsetAds;
 - (void)deleteItemsAtIndexPaths:(NSArray *)originalIndexPaths;
 - (void)moveItemAtIndexPath:(NSIndexPath *)originalIndexPath toIndexPath:(NSIndexPath *)newIndexPath;
 

--- a/MoPubSDK/Native Ads/MPStreamAdPlacementData.m
+++ b/MoPubSDK/Native Ads/MPStreamAdPlacementData.m
@@ -323,7 +323,13 @@ static const NSUInteger kMaximumNumberOfAdsPerStream = 255;
     [self updateAllSectionsForPositioningArraysAtSection:newSection];
 }
 
+
 - (void)insertItemsAtIndexPaths:(NSArray *)originalIndexPaths
+{
+    [self insertItemsAtIndexPaths:originalIndexPaths offsetAds:true];
+}
+
+- (void)insertItemsAtIndexPaths:(NSArray *)originalIndexPaths offsetAds:(Boolean)offsetAds
 {
     originalIndexPaths = [originalIndexPaths sortedArrayUsingSelector:@selector(compare:)];
 
@@ -331,14 +337,16 @@ static const NSUInteger kMaximumNumberOfAdsPerStream = 255;
         NSMutableArray *desiredOriginalPositions = [self positioningArrayForSection:originalIndexPath.section inDictionary:self.desiredOriginalPositions];
         NSMutableArray *originalAdIndexPaths = [self positioningArrayForSection:originalIndexPath.section inDictionary:self.originalAdIndexPaths];
 
-        NSUInteger insertionIndex = [self indexOfIndexPath:originalIndexPath inSortedArray:desiredOriginalPositions options:NSBinarySearchingInsertionIndex | NSBinarySearchingFirstEqual];
-        for (NSUInteger i = insertionIndex; i < [desiredOriginalPositions count]; i++) {
-            [self incrementDesiredIndexPathsAtIndex:i inSection:originalIndexPath.section];
-        }
+        if(offsetAds) {
+            NSUInteger insertionIndex = [self indexOfIndexPath:originalIndexPath inSortedArray:desiredOriginalPositions options:NSBinarySearchingInsertionIndex | NSBinarySearchingFirstEqual];
+            for (NSUInteger i = insertionIndex; i < [desiredOriginalPositions count]; i++) {
+                [self incrementDesiredIndexPathsAtIndex:i inSection:originalIndexPath.section];
+            }
 
-        NSUInteger originalInsertionIndex = [self indexOfIndexPath:originalIndexPath inSortedArray:originalAdIndexPaths options:NSBinarySearchingInsertionIndex | NSBinarySearchingFirstEqual];
-        for (NSUInteger i = originalInsertionIndex; i < [originalAdIndexPaths count]; i++) {
-            [self incrementPlacedIndexPathsAtIndex:i inSection:originalIndexPath.section];
+            NSUInteger originalInsertionIndex = [self indexOfIndexPath:originalIndexPath inSortedArray:originalAdIndexPaths options:NSBinarySearchingInsertionIndex | NSBinarySearchingFirstEqual];
+            for (NSUInteger i = originalInsertionIndex; i < [originalAdIndexPaths count]; i++) {
+                [self incrementPlacedIndexPathsAtIndex:i inSection:originalIndexPath.section];
+            }
         }
     }];
 }

--- a/MoPubSDK/Native Ads/MPStreamAdPlacer.h
+++ b/MoPubSDK/Native Ads/MPStreamAdPlacer.h
@@ -188,6 +188,16 @@
 - (void)insertItemsAtIndexPaths:(NSArray *)originalIndexPaths;
 
 /**
+ * Tells the ad placer that content items have been inserted at the specified index paths.
+ *
+ * This method allows the ad placer to adjust its ad positions correctly.
+ *
+ * @param originalIndexPaths An array of NSIndexPath objects that identify positions where content
+ * @param offsetAds : if true, ad placer will offset ads, otherwise it wont
+ * has been inserted.
+ */
+- (void)insertItemsAtIndexPaths:(NSArray *)originalIndexPaths offsetAds:(Boolean)offsetAds;
+/**
  * Tells the ad placer that content items have been deleted at the specified index paths.
  *
  * This method allows the ad placer to adjust its ad positions correctly, and remove from the

--- a/MoPubSDK/Native Ads/MPStreamAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPStreamAdPlacer.m
@@ -238,7 +238,12 @@ static const NSUInteger kIndexPathItemIndex = 1;
 
 - (void)insertItemsAtIndexPaths:(NSArray *)originalIndexPaths
 {
-    [self.adPlacementData insertItemsAtIndexPaths:originalIndexPaths];
+    [self insertItemsAtIndexPaths:originalIndexPaths offsetAds:true];
+}
+
+- (void)insertItemsAtIndexPaths:(NSArray *)originalIndexPaths offsetAds:(Boolean)offsetAds
+{
+    [self.adPlacementData insertItemsAtIndexPaths:originalIndexPaths offsetAds:offsetAds];
     [originalIndexPaths enumerateObjectsUsingBlock:^(NSIndexPath *originalIndexPath, NSUInteger idx, BOOL *stop) {
         NSInteger section = originalIndexPath.section;
         [self setItemCount:[[self.sectionCounts objectForKey:@(section)] integerValue] + 1 forSection:section];

--- a/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
@@ -675,11 +675,16 @@ static char kAdPlacerKey;
 
 - (void)mp_insertRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation
 {
+    [self mp_insertRowsAtIndexPaths:indexPaths withRowAnimation:animation offsetAds:true];
+}
+
+- (void)mp_insertRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation offsetAds:(Boolean)offsetAds
+{
     MPTableViewAdPlacer *adPlacer = [self mp_adPlacer];
     NSArray *adjustedIndexPaths = indexPaths;
 
     if (adPlacer) {
-        [adPlacer.streamAdPlacer insertItemsAtIndexPaths:indexPaths];
+        [adPlacer.streamAdPlacer insertItemsAtIndexPaths:indexPaths offsetAds:offsetAds];
         adjustedIndexPaths = [adPlacer.streamAdPlacer adjustedIndexPathsForOriginalIndexPaths:indexPaths];
     }
 


### PR DESCRIPTION
This PR adds an optional flag "offsetAds" to the mp_insertItemAtIndexPath... methods in MPCollectionViewAdapter and MPTableViewAdapter. This allow the developer to insert items in the stream without offsetting ads.

This is handy when you never use reloadData, but use insertItems, for example when loading new data at the end of the stream.