### PR TITLE
mp_visibleCells was causing a crash

### DIFF
--- a/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
+++ b/MoPubSDK/Native Ads/MPTableViewAdPlacer.m
@@ -573,7 +573,7 @@ static char kAdPlacerKey;
     return indexPaths;
 }
 
-- (UITableViewCell *)mp_cellForRowAtIndexPath:(NSIndexPath *)indexPath
+- (nullable UITableViewCell *)mp_cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     MPTableViewAdPlacer *adPlacer = [self mp_adPlacer];
     NSIndexPath *adjustedIndexPath = indexPath;
@@ -593,7 +593,10 @@ static char kAdPlacerKey;
         NSArray *indexPaths = [self mp_indexPathsForVisibleRows];
         NSMutableArray *visibleCells = [NSMutableArray array];
         for (NSIndexPath *indexPath in indexPaths) {
-            [visibleCells addObject:[self mp_cellForRowAtIndexPath:indexPath]];
+			UITableViewCell *cell = [self mp_cellForRowAtIndexPath:indexPath];
+			if (cell) {
+				[visibleCells addObject:cell];
+			}
         }
         return visibleCells;
     } else {


### PR DESCRIPTION
mp_visibleCells was ignoring the possibility of mp_cellForRowAtIndexPath (ultimately UITableView:cellForRowAtIndexPath) returning nil