### PR TITLE
Fix facebook native ad not able to be clicked when shown in MoPub table view

### DIFF
--- a/MoPubSDK/Native Ads/MPNativeAd.m
+++ b/MoPubSDK/Native Ads/MPNativeAd.m
@@ -80,7 +80,10 @@
     // We always return the same MPNativeView (self.associatedView) so we need to remove its subviews
     // before attaching the new ad view to it.
     [[self.associatedView subviews] makeObjectsPerformSelector:@selector(removeFromSuperview)];
-
+    if (self.associatedView.subviews.count == 0) {
+        self.hasAttachedToView = NO;
+    }
+    
     UIView *adView = [self.renderer retrieveViewWithAdapter:self.adAdapter error:error];
 
     if (adView) {


### PR DESCRIPTION
The issues happens by reproducing it in following ways:
 
From MoPub Sample app (iOS):
1 Create AdUnits to show Native Ad in table view
2 Tap the AdUnit which will show the ads in table view.  Tap the ads which works the first time and launch the ad link.
3 Scroll up and down multiple times and tap the ad again which will not launch the ad link.
 
The cause happens in the MoPub 4.17 release with following diff:
 
https://github.com/mopub/mopub-ios-sdk/pull/211/files
 
 
What PR 211 does:
 
MPNativeAd class is the model that holds the native ad views.  When ad views are created, it registers the root view which is called associated view to be tap-able for interaction.  This violates Facebook policy as the whole view including  all the subviews’ ad assets and whitespace regions are tap-able.
 
The fix from pull 211 fixed the issue by calling willAttachToView:withAdContentViews this allows MoPub SDK to register only views that contain ad assets not the whole view.
 
Why PR 211 cause this bug:
 
willAttachToView:withAdContentViews is called only once when MPNativeAd’s property hasAttachedToView is false which will be set to true after views are attached.
This works fine for showing Native Ad as a single view container.
 
For table views, each cell in the table view is reusable and the content in the cell will be removed when it’s no visible after scrolling.  This means all the ad content views that were registered for tap-able at beginning will be removed and unregistered from Facebook Native Ad object.
When the ad content is shown again, all the ad content views are newly created.  At this point, MPNativeAd’s property hasAttachedToView is true as it was set after views were registered first time; therefore all the new ad content views are not registered for tap-able with Facebook Native Ad object.  This causes the cell that contains Facebook ad can not be tapped to load the link.
 
Suggested Solution To Fix:
 
When the ad content views were removed, MPNativeAd’s property hasAttachedToView needs to be set to false again.  This will call the willAttachToView:withAdContentViews and the ad content views will be registered for interaction again.  For example:
 
    if (self.associatedView.subviews.count == 0) {
        self.hasAttachedToView = NO;
    }