### PR TITLE
Update to NSURLSession in several places

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdServerCommunicator.h
+++ b/MoPubSDK/Internal/Common/MPAdServerCommunicator.h
@@ -14,7 +14,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@interface MPAdServerCommunicator : NSObject <NSURLConnectionDataDelegate>
+@interface MPAdServerCommunicator : NSObject <NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 
 @property (nonatomic, weak) id<MPAdServerCommunicatorDelegate> delegate;
 @property (nonatomic, assign, readonly) BOOL loading;

--- a/MoPubSDK/Native Ads/MPNativeAd.m
+++ b/MoPubSDK/Native Ads/MPNativeAd.m
@@ -31,6 +31,8 @@
 @property (nonatomic, strong) NSMutableSet *clickTrackerURLs;
 @property (nonatomic, strong) NSMutableSet *impressionTrackerURLs;
 
+@property (nonatomic, weak) NSURLSessionTask *dataTask;
+
 @property (nonatomic, readonly, strong) id<MPNativeAdAdapter> adAdapter;
 @property (nonatomic, assign) BOOL hasTrackedImpression;
 @property (nonatomic, assign) BOOL hasTrackedClick;
@@ -143,10 +145,10 @@
 {
     NSMutableURLRequest *request = [[MPCoreInstanceProvider sharedProvider] buildConfiguredURLRequestWithURL:URL];
     request.cachePolicy = NSURLRequestReloadIgnoringCacheData;
-
-    NSURLConnection * connection = [[NSURLConnection alloc] initWithRequest:request delegate:nil startImmediately:NO];
-    [connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
-    [connection start];
+    
+    NSURLSession *session = [NSURLSession sharedSession];
+    self.dataTask = [session dataTaskWithRequest:request];
+    [self.dataTask resume];
 }
 
 #pragma mark - Internal


### PR DESCRIPTION
We faced a lot of crashes related to networking after integration of the mopub sdk. 
As an experiment, we decided to update requests to NSURLSession in most used parts of the code, and it helped.

Stacktraces (crashes occur inside CFNetwork):
> 1 TCPIOConnection::copyProperty(__CFString const*) + 44
> 2 SPDYConnection::_onqueue_closeStream(SPDYStream*) + 232
> 3 ___ZN14SPDYConnection19startEnqueuedStreamEP10SPDYStream_block_invoke_2 + 24

> 1 objc_retain + 16
> 2 HTTPProtocol::useNetStreamInfoForRequest(MetaNetStreamInfo*, HTTPRequestMessage const*, unsigned char) + 236
> 3 SPDYConnectionCacheEntry::enqueueRequestForProtocol(MetaConnectionCacheClient*, HTTPRequestMessage const*, MetaConnectionOptions) + 344
