### PR TITLE
Set mediation service for Facebook adapter

### DIFF
--- a/AdNetworkSupport/Facebook/FacebookBannerCustomEvent.m
+++ b/AdNetworkSupport/Facebook/FacebookBannerCustomEvent.m
@@ -97,6 +97,7 @@
     fbAdFrame.size = size;
     self.fbAdView.frame = fbAdFrame;
 
+    [FBAdSettings setMediationService:[NSString stringWithFormat:@"MOPUB_%@", MP_SDK_VERSION]];
     [self.fbAdView loadAd];
 }
 

--- a/AdNetworkSupport/Facebook/FacebookInterstitialCustomEvent.m
+++ b/AdNetworkSupport/Facebook/FacebookInterstitialCustomEvent.m
@@ -52,6 +52,7 @@
     [[MPInstanceProvider sharedProvider] buildFBInterstitialAdWithPlacementID:[info objectForKey:@"placement_id"]
                                                                      delegate:self];
 
+    [FBAdSettings setMediationService:[NSString stringWithFormat:@"MOPUB_%@", MP_SDK_VERSION]];
     [self.fbInterstitialAd loadAd];
 }
 

--- a/AdNetworkSupport/Facebook/FacebookNativeCustomEvent.m
+++ b/AdNetworkSupport/Facebook/FacebookNativeCustomEvent.m
@@ -43,6 +43,7 @@ static BOOL gVideoEnabled = NO;
     if (placementID) {
         _fbNativeAd = [[FBNativeAd alloc] initWithPlacementID:placementID];
         self.fbNativeAd.delegate = self;
+        [FBAdSettings setMediationService:[NSString stringWithFormat:@"MOPUB_%@", MP_SDK_VERSION]];
         [self.fbNativeAd loadAd];
     } else {
         [self.delegate nativeCustomEvent:self didFailToLoadAdWithError:MPNativeAdNSErrorForInvalidAdServerResponse(@"Invalid Facebook placement ID")];

--- a/AdNetworkSupport/Facebook/FacebookRewardedVideoCustomEvent.m
+++ b/AdNetworkSupport/Facebook/FacebookRewardedVideoCustomEvent.m
@@ -57,6 +57,7 @@
     self.fbRewardedVideoAd =
     [[MPInstanceProvider sharedProvider] buildFBRewardedVideoAdWithPlacementID: [info objectForKey:@"placement_id"] delegate:self];
 
+    [FBAdSettings setMediationService:[NSString stringWithFormat:@"MOPUB_%@", MP_SDK_VERSION]];
     [self.fbRewardedVideoAd loadAd];
 }
 


### PR DESCRIPTION
This diff sets the mediation service using FBAdSettings from Audience Network SDK.  It's important for Audience Network SDK to collection mediation service string for reporting.  All codes are changed in the Facebook Audience Network adapter so there is no side effect in MoPub SDK.  