### PR TITLE
Make sure view controller are properly deallocated after dismiss

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdDestinationDisplayAgent.m
+++ b/MoPubSDK/Internal/Common/MPAdDestinationDisplayAgent.m
@@ -324,6 +324,10 @@ static NSString * const kDisplayAgentErrorDomain = @"com.mopub.displayagent";
 {
     self.isLoadingDestination = NO;
     [self hideModalAndNotifyDelegate];
+    // Added by Elton: make sure vc is properly deallocated after dismiss
+    if (viewController == self.storeKitController) {
+        self.storeKitController = nil;
+    }
 }
 
 #pragma mark - <MPAdBrowserControllerDelegate>
@@ -332,6 +336,10 @@ static NSString * const kDisplayAgentErrorDomain = @"com.mopub.displayagent";
 {
     self.isLoadingDestination = NO;
     [self hideModalAndNotifyDelegate];
+    // Added by Elton: make sure vc is properly deallocated after dismiss
+    if (browserController == self.browserController) {
+        self.browserController = nil;
+    }
 }
 
 - (MPAdConfiguration *)adConfiguration


### PR DESCRIPTION
For places that show store kit view controller or web browser, after they are dismissed, their memory is not cleared until next store kit vc or web browser shows because there is still a strong reference to it. Setting the property to nil will release the memory in time