### PR TITLE
Avoid symbol collision by adding vendor prefix

### DIFF
--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -223,7 +223,7 @@
         return;
     }
 
-    if ([configuration.networkType isEqualToString:kAdTypeClear]) {
+    if ([configuration.networkType isEqualToString:kMPAdTypeClear]) {
         MPLogInfo(kMPClearErrorLogFormatWithAdUnitID, self.delegate.adUnitId);
         [self didFailToLoadAdapterWithError:[MOPUBError errorWithCode:MOPUBErrorNoInventory]];
         return;

--- a/MoPubSDK/Internal/Common/MPAdConfiguration.h
+++ b/MoPubSDK/Internal/Common/MPAdConfiguration.h
@@ -17,50 +17,50 @@ enum {
 };
 typedef NSUInteger MPAdType;
 
-extern NSString * const kAdTypeHeaderKey;
-extern NSString * const kAdUnitWarmingUpHeaderKey;
-extern NSString * const kClickthroughHeaderKey;
-extern NSString * const kCreativeIdHeaderKey;
-extern NSString * const kCustomSelectorHeaderKey;
-extern NSString * const kCustomEventClassNameHeaderKey;
-extern NSString * const kCustomEventClassDataHeaderKey;
-extern NSString * const kFailUrlHeaderKey;
-extern NSString * const kHeightHeaderKey;
-extern NSString * const kImpressionTrackerHeaderKey;
-extern NSString * const kInterceptLinksHeaderKey;
-extern NSString * const kLaunchpageHeaderKey;
-extern NSString * const kNativeSDKParametersHeaderKey;
-extern NSString * const kNetworkTypeHeaderKey;
-extern NSString * const kRefreshTimeHeaderKey;
-extern NSString * const kAdTimeoutHeaderKey;
-extern NSString * const kScrollableHeaderKey;
-extern NSString * const kWidthHeaderKey;
-extern NSString * const kDspCreativeIdKey;
-extern NSString * const kPrecacheRequiredKey;
-extern NSString * const kIsVastVideoPlayerKey;
-extern NSString * const kRewardedVideoCurrencyNameHeaderKey;
-extern NSString * const kRewardedVideoCurrencyAmountHeaderKey;
-extern NSString * const kRewardedVideoCompletionUrlHeaderKey;
-extern NSString * const kRewardedCurrenciesHeaderKey;
-extern NSString * const kRewardedPlayableDurationHeaderKey;
-extern NSString * const kRewardedPlayableRewardOnClickHeaderKey;
+extern NSString * const kMPAdTypeHeaderKey;
+extern NSString * const kMPAdUnitWarmingUpHeaderKey;
+extern NSString * const kMPClickthroughHeaderKey;
+extern NSString * const kMPCreativeIdHeaderKey;
+extern NSString * const kMPCustomSelectorHeaderKey;
+extern NSString * const kMPCustomEventClassNameHeaderKey;
+extern NSString * const kMPCustomEventClassDataHeaderKey;
+extern NSString * const kMPFailUrlHeaderKey;
+extern NSString * const kMPHeightHeaderKey;
+extern NSString * const kMPImpressionTrackerHeaderKey;
+extern NSString * const kMPInterceptLinksHeaderKey;
+extern NSString * const kMPLaunchpageHeaderKey;
+extern NSString * const kMPNativeSDKParametersHeaderKey;
+extern NSString * const kMPNetworkTypeHeaderKey;
+extern NSString * const kMPRefreshTimeHeaderKey;
+extern NSString * const kMPAdTimeoutHeaderKey;
+extern NSString * const kMPScrollableHeaderKey;
+extern NSString * const kMPWidthHeaderKey;
+extern NSString * const kMPDspCreativeIdKey;
+extern NSString * const kMPPrecacheRequiredKey;
+extern NSString * const kMPIsVastVideoPlayerKey;
+extern NSString * const kMPRewardedVideoCurrencyNameHeaderKey;
+extern NSString * const kMPRewardedVideoCurrencyAmountHeaderKey;
+extern NSString * const kMPRewardedVideoCompletionUrlHeaderKey;
+extern NSString * const kMPRewardedCurrenciesHeaderKey;
+extern NSString * const kMPRewardedPlayableDurationHeaderKey;
+extern NSString * const kMPRewardedPlayableRewardOnClickHeaderKey;
 
-extern NSString * const kInterstitialAdTypeHeaderKey;
-extern NSString * const kOrientationTypeHeaderKey;
+extern NSString * const kMPInterstitialAdTypeHeaderKey;
+extern NSString * const kMPOrientationTypeHeaderKey;
 
-extern NSString * const kAdTypeHtml;
-extern NSString * const kAdTypeInterstitial;
-extern NSString * const kAdTypeMraid;
-extern NSString * const kAdTypeClear;
-extern NSString * const kAdTypeNative;
-extern NSString * const kAdTypeNativeVideo;
+extern NSString * const kMPAdTypeHtml;
+extern NSString * const kMPAdTypeInterstitial;
+extern NSString * const kMPAdTypeMraid;
+extern NSString * const kMPAdTypeClear;
+extern NSString * const kMPAdTypeNative;
+extern NSString * const kMPAdTypeNativeVideo;
 
-extern NSString * const kClickthroughExperimentBrowserAgent;
+extern NSString * const kMPClickthroughExperimentBrowserAgent;
 
-extern NSString * const kViewabilityDisableHeaderKey;
+extern NSString * const kMPViewabilityDisableHeaderKey;
 
-extern NSString * const kBannerImpressionVisableMsHeaderKey;
-extern NSString * const kBannerImpressionMinPixelHeaderKey;
+extern NSString * const kMPBannerImpressionVisableMsHeaderKey;
+extern NSString * const kMPBannerImpressionMinPixelHeaderKey;
 
 @interface MPAdConfiguration : NSObject
 

--- a/MoPubSDK/Internal/Common/MPAdConfiguration.m
+++ b/MoPubSDK/Internal/Common/MPAdConfiguration.m
@@ -20,72 +20,72 @@
 #import "MPVASTTrackingEvent.h"
 #endif
 
-NSString * const kAdTypeHeaderKey = @"X-Adtype";
-NSString * const kAdUnitWarmingUpHeaderKey = @"X-Warmup";
-NSString * const kClickthroughHeaderKey = @"X-Clickthrough";
-NSString * const kCreativeIdHeaderKey = @"X-CreativeId";
-NSString * const kCustomSelectorHeaderKey = @"X-Customselector";
-NSString * const kCustomEventClassNameHeaderKey = @"X-Custom-Event-Class-Name";
-NSString * const kCustomEventClassDataHeaderKey = @"X-Custom-Event-Class-Data";
-NSString * const kFailUrlHeaderKey = @"X-Failurl";
-NSString * const kHeightHeaderKey = @"X-Height";
-NSString * const kImpressionTrackerHeaderKey = @"X-Imptracker";
-NSString * const kInterceptLinksHeaderKey = @"X-Interceptlinks";
-NSString * const kLaunchpageHeaderKey = @"X-Launchpage";
-NSString * const kNativeSDKParametersHeaderKey = @"X-Nativeparams";
-NSString * const kNetworkTypeHeaderKey = @"X-Networktype";
-NSString * const kRefreshTimeHeaderKey = @"X-Refreshtime";
-NSString * const kAdTimeoutHeaderKey = @"X-AdTimeout";
-NSString * const kScrollableHeaderKey = @"X-Scrollable";
-NSString * const kWidthHeaderKey = @"X-Width";
-NSString * const kDspCreativeIdKey = @"X-DspCreativeid";
-NSString * const kPrecacheRequiredKey = @"X-PrecacheRequired";
-NSString * const kIsVastVideoPlayerKey = @"X-VastVideoPlayer";
+NSString * const kMPAdTypeHeaderKey = @"X-Adtype";
+NSString * const kMPAdUnitWarmingUpHeaderKey = @"X-Warmup";
+NSString * const kMPClickthroughHeaderKey = @"X-Clickthrough";
+NSString * const kMPCreativeIdHeaderKey = @"X-CreativeId";
+NSString * const kMPCustomSelectorHeaderKey = @"X-Customselector";
+NSString * const kMPCustomEventClassNameHeaderKey = @"X-Custom-Event-Class-Name";
+NSString * const kMPCustomEventClassDataHeaderKey = @"X-Custom-Event-Class-Data";
+NSString * const kMPFailUrlHeaderKey = @"X-Failurl";
+NSString * const kMPHeightHeaderKey = @"X-Height";
+NSString * const kMPImpressionTrackerHeaderKey = @"X-Imptracker";
+NSString * const kMPInterceptLinksHeaderKey = @"X-Interceptlinks";
+NSString * const kMPLaunchpageHeaderKey = @"X-Launchpage";
+NSString * const kMPNativeSDKParametersHeaderKey = @"X-Nativeparams";
+NSString * const kMPNetworkTypeHeaderKey = @"X-Networktype";
+NSString * const kMPRefreshTimeHeaderKey = @"X-Refreshtime";
+NSString * const kMPAdTimeoutHeaderKey = @"X-AdTimeout";
+NSString * const kMPScrollableHeaderKey = @"X-Scrollable";
+NSString * const kMPWidthHeaderKey = @"X-Width";
+NSString * const kMPDspCreativeIdKey = @"X-DspCreativeid";
+NSString * const kMPPrecacheRequiredKey = @"X-PrecacheRequired";
+NSString * const kMPIsVastVideoPlayerKey = @"X-VastVideoPlayer";
 
-NSString * const kInterstitialAdTypeHeaderKey = @"X-Fulladtype";
-NSString * const kOrientationTypeHeaderKey = @"X-Orientation";
+NSString * const kMPInterstitialAdTypeHeaderKey = @"X-Fulladtype";
+NSString * const kMPOrientationTypeHeaderKey = @"X-Orientation";
 
-NSString * const kNativeImpressionMinVisiblePixelsHeaderKey = @"X-Native-Impression-Min-Px"; // The pixels header takes priority over percentage, but percentage is left for backwards compatibility
-NSString * const kNativeImpressionMinVisiblePercentHeaderKey = @"X-Impression-Min-Visible-Percent";
-NSString * const kNativeImpressionVisibleMsHeaderKey = @"X-Impression-Visible-Ms";
-NSString * const kNativeVideoPlayVisiblePercentHeaderKey = @"X-Play-Visible-Percent";
-NSString * const kNativeVideoPauseVisiblePercentHeaderKey = @"X-Pause-Visible-Percent";
-NSString * const kNativeVideoMaxBufferingTimeMsHeaderKey = @"X-Max-Buffer-Ms";
-NSString * const kNativeVideoTrackersHeaderKey = @"X-Video-Trackers";
+NSString * const kMPNativeImpressionMinVisiblePixelsHeaderKey = @"X-Native-Impression-Min-Px"; // The pixels header takes priority over percentage, but percentage is left for backwards compatibility
+NSString * const kMPNativeImpressionMinVisiblePercentHeaderKey = @"X-Impression-Min-Visible-Percent";
+NSString * const kMPNativeImpressionVisibleMsHeaderKey = @"X-Impression-Visible-Ms";
+NSString * const kMPNativeVideoPlayVisiblePercentHeaderKey = @"X-Play-Visible-Percent";
+NSString * const kMPNativeVideoPauseVisiblePercentHeaderKey = @"X-Pause-Visible-Percent";
+NSString * const kMPNativeVideoMaxBufferingTimeMsHeaderKey = @"X-Max-Buffer-Ms";
+NSString * const kMPNativeVideoTrackersHeaderKey = @"X-Video-Trackers";
 
-NSString * const kBannerImpressionVisableMsHeaderKey = @"X-Banner-Impression-Min-Ms";
-NSString * const kBannerImpressionMinPixelHeaderKey = @"X-Banner-Impression-Min-Pixels";
+NSString * const kMPBannerImpressionVisableMsHeaderKey = @"X-Banner-Impression-Min-Ms";
+NSString * const kMPBannerImpressionMinPixelHeaderKey = @"X-Banner-Impression-Min-Pixels";
 
-NSString * const kAdTypeHtml = @"html";
-NSString * const kAdTypeInterstitial = @"interstitial";
-NSString * const kAdTypeMraid = @"mraid";
-NSString * const kAdTypeClear = @"clear";
-NSString * const kAdTypeNative = @"json";
-NSString * const kAdTypeNativeVideo = @"json_video";
+NSString * const kMPAdTypeHtml = @"html";
+NSString * const kMPAdTypeInterstitial = @"interstitial";
+NSString * const kMPAdTypeMraid = @"mraid";
+NSString * const kMPAdTypeClear = @"clear";
+NSString * const kMPAdTypeNative = @"json";
+NSString * const kMPAdTypeNativeVideo = @"json_video";
 
 // rewarded video
-NSString * const kRewardedVideoCurrencyNameHeaderKey = @"X-Rewarded-Video-Currency-Name";
-NSString * const kRewardedVideoCurrencyAmountHeaderKey = @"X-Rewarded-Video-Currency-Amount";
-NSString * const kRewardedVideoCompletionUrlHeaderKey = @"X-Rewarded-Video-Completion-Url";
-NSString * const kRewardedCurrenciesHeaderKey = @"X-Rewarded-Currencies";
+NSString * const kMPRewardedVideoCurrencyNameHeaderKey = @"X-Rewarded-Video-Currency-Name";
+NSString * const kMPRewardedVideoCurrencyAmountHeaderKey = @"X-Rewarded-Video-Currency-Amount";
+NSString * const kMPRewardedVideoCompletionUrlHeaderKey = @"X-Rewarded-Video-Completion-Url";
+NSString * const kMPRewardedCurrenciesHeaderKey = @"X-Rewarded-Currencies";
 
 // rewarded playables
-NSString * const kRewardedPlayableDurationHeaderKey = @"X-Rewarded-Duration";
-NSString * const kRewardedPlayableRewardOnClickHeaderKey = @"X-Should-Reward-On-Click";
+NSString * const kMPRewardedPlayableDurationHeaderKey = @"X-Rewarded-Duration";
+NSString * const kMPRewardedPlayableRewardOnClickHeaderKey = @"X-Should-Reward-On-Click";
 
 // native video
-NSString * const kNativeVideoTrackerUrlMacro = @"%%VIDEO_EVENT%%";
-NSString * const kNativeVideoTrackerEventsHeaderKey = @"events";
-NSString * const kNativeVideoTrackerUrlsHeaderKey = @"urls";
-NSString * const kNativeVideoTrackerEventDictionaryKey = @"event";
-NSString * const kNativeVideoTrackerTextDictionaryKey = @"text";
+NSString * const kMPNativeVideoTrackerUrlMacro = @"%%VIDEO_EVENT%%";
+NSString * const kMPNativeVideoTrackerEventsHeaderKey = @"events";
+NSString * const kMPNativeVideoTrackerUrlsHeaderKey = @"urls";
+NSString * const kMPNativeVideoTrackerEventDictionaryKey = @"event";
+NSString * const kMPNativeVideoTrackerTextDictionaryKey = @"text";
 
 // clickthrough experiment
-NSString * const kClickthroughExperimentBrowserAgent = @"X-Browser-Agent";
-static const NSInteger kMaximumVariantForClickthroughExperiment = 2;
+NSString * const kMPClickthroughExperimentBrowserAgent = @"X-Browser-Agent";
+static const NSInteger kMPMaximumVariantForClickthroughExperiment = 2;
 
 // viewability
-NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
+NSString * const kMPViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
 
 @interface MPAdConfiguration ()
@@ -115,33 +115,33 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
         self.adType = [self adTypeFromHeaders:headers];
 
-        self.adUnitWarmingUp = [[headers objectForKey:kAdUnitWarmingUpHeaderKey] boolValue];
+        self.adUnitWarmingUp = [[headers objectForKey:kMPAdUnitWarmingUpHeaderKey] boolValue];
 
         self.networkType = [self networkTypeFromHeaders:headers];
         self.networkType = self.networkType ? self.networkType : @"";
 
-        self.preferredSize = CGSizeMake([[headers objectForKey:kWidthHeaderKey] floatValue],
-                                        [[headers objectForKey:kHeightHeaderKey] floatValue]);
+        self.preferredSize = CGSizeMake([[headers objectForKey:kMPWidthHeaderKey] floatValue],
+                                        [[headers objectForKey:kMPHeightHeaderKey] floatValue]);
 
         self.clickTrackingURL = [self URLFromHeaders:headers
-                                              forKey:kClickthroughHeaderKey];
+                                              forKey:kMPClickthroughHeaderKey];
         self.impressionTrackingURL = [self URLFromHeaders:headers
-                                                   forKey:kImpressionTrackerHeaderKey];
+                                                   forKey:kMPImpressionTrackerHeaderKey];
         self.failoverURL = [self URLFromHeaders:headers
-                                         forKey:kFailUrlHeaderKey];
+                                         forKey:kMPFailUrlHeaderKey];
         self.interceptURLPrefix = [self URLFromHeaders:headers
-                                                forKey:kLaunchpageHeaderKey];
+                                                forKey:kMPLaunchpageHeaderKey];
 
-        NSNumber *shouldInterceptLinks = [headers objectForKey:kInterceptLinksHeaderKey];
+        NSNumber *shouldInterceptLinks = [headers objectForKey:kMPInterceptLinksHeaderKey];
         self.shouldInterceptLinks = shouldInterceptLinks ? [shouldInterceptLinks boolValue] : YES;
-        self.scrollable = [[headers objectForKey:kScrollableHeaderKey] boolValue];
+        self.scrollable = [[headers objectForKey:kMPScrollableHeaderKey] boolValue];
         self.refreshInterval = [self refreshIntervalFromHeaders:headers];
-        self.adTimeoutInterval = [self timeIntervalFromHeaders:headers forKey:kAdTimeoutHeaderKey];
+        self.adTimeoutInterval = [self timeIntervalFromHeaders:headers forKey:kMPAdTimeoutHeaderKey];
 
 
         self.nativeSDKParameters = [self dictionaryFromHeaders:headers
-                                                        forKey:kNativeSDKParametersHeaderKey];
-        self.customSelectorName = [headers objectForKey:kCustomSelectorHeaderKey];
+                                                        forKey:kMPNativeSDKParametersHeaderKey];
+        self.customSelectorName = [headers objectForKey:kMPCustomSelectorHeaderKey];
 
         self.orientationType = [self orientationTypeFromHeaders:headers];
 
@@ -149,35 +149,35 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
         self.customEventClassData = [self customEventClassDataFromHeaders:headers];
 
-        self.dspCreativeId = [headers objectForKey:kDspCreativeIdKey];
+        self.dspCreativeId = [headers objectForKey:kMPDspCreativeIdKey];
 
-        self.precacheRequired = [[headers objectForKey:kPrecacheRequiredKey] boolValue];
+        self.precacheRequired = [[headers objectForKey:kMPPrecacheRequiredKey] boolValue];
 
-        self.isVastVideoPlayer = [[headers objectForKey:kIsVastVideoPlayerKey] boolValue];
+        self.isVastVideoPlayer = [[headers objectForKey:kMPIsVastVideoPlayerKey] boolValue];
 
         self.creationTimestamp = [NSDate date];
 
-        self.creativeId = [headers objectForKey:kCreativeIdHeaderKey];
+        self.creativeId = [headers objectForKey:kMPCreativeIdHeaderKey];
 
-        self.headerAdType = [headers objectForKey:kAdTypeHeaderKey];
+        self.headerAdType = [headers objectForKey:kMPAdTypeHeaderKey];
 
-        self.nativeVideoPlayVisiblePercent = [self percentFromHeaders:headers forKey:kNativeVideoPlayVisiblePercentHeaderKey];
+        self.nativeVideoPlayVisiblePercent = [self percentFromHeaders:headers forKey:kMPNativeVideoPlayVisiblePercentHeaderKey];
 
-        self.nativeVideoPauseVisiblePercent = [self percentFromHeaders:headers forKey:kNativeVideoPauseVisiblePercentHeaderKey];
+        self.nativeVideoPauseVisiblePercent = [self percentFromHeaders:headers forKey:kMPNativeVideoPauseVisiblePercentHeaderKey];
 
-        self.nativeImpressionMinVisiblePixels = [[self adAmountFromHeaders:headers key:kNativeImpressionMinVisiblePixelsHeaderKey] floatValue];
+        self.nativeImpressionMinVisiblePixels = [[self adAmountFromHeaders:headers key:kMPNativeImpressionMinVisiblePixelsHeaderKey] floatValue];
 
-        self.nativeImpressionMinVisiblePercent = [self percentFromHeaders:headers forKey:kNativeImpressionMinVisiblePercentHeaderKey];
+        self.nativeImpressionMinVisiblePercent = [self percentFromHeaders:headers forKey:kMPNativeImpressionMinVisiblePercentHeaderKey];
 
-        self.nativeImpressionMinVisibleTimeInterval = [self timeIntervalFromMsHeaders:headers forKey:kNativeImpressionVisibleMsHeaderKey];
+        self.nativeImpressionMinVisibleTimeInterval = [self timeIntervalFromMsHeaders:headers forKey:kMPNativeImpressionVisibleMsHeaderKey];
 
-        self.nativeVideoMaxBufferingTime = [self timeIntervalFromMsHeaders:headers forKey:kNativeVideoMaxBufferingTimeMsHeaderKey];
+        self.nativeVideoMaxBufferingTime = [self timeIntervalFromMsHeaders:headers forKey:kMPNativeVideoMaxBufferingTimeMsHeaderKey];
 #if MP_HAS_NATIVE_PACKAGE
-        self.nativeVideoTrackers = [self nativeVideoTrackersFromHeaders:headers key:kNativeVideoTrackersHeaderKey];
+        self.nativeVideoTrackers = [self nativeVideoTrackersFromHeaders:headers key:kMPNativeVideoTrackersHeaderKey];
 #endif
 
-        self.impressionMinVisibleTimeInSec = [self timeIntervalFromMsHeaders:headers forKey:kBannerImpressionVisableMsHeaderKey];
-        self.impressionMinVisiblePixels = [[self adAmountFromHeaders:headers key:kBannerImpressionMinPixelHeaderKey] floatValue];
+        self.impressionMinVisibleTimeInSec = [self timeIntervalFromMsHeaders:headers forKey:kMPBannerImpressionVisableMsHeaderKey];
+        self.impressionMinVisiblePixels = [[self adAmountFromHeaders:headers key:kMPBannerImpressionMinPixelHeaderKey] floatValue];
 
         // rewarded video
 
@@ -201,9 +201,9 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
         // Multiple currencies are not available; attempt to process single currency
         // headers.
         else {
-            NSString *currencyName = [headers objectForKey:kRewardedVideoCurrencyNameHeaderKey] ?: kMPRewardedVideoRewardCurrencyTypeUnspecified;
+            NSString *currencyName = [headers objectForKey:kMPRewardedVideoCurrencyNameHeaderKey] ?: kMPRewardedVideoRewardCurrencyTypeUnspecified;
 
-            NSNumber *currencyAmount = [self adAmountFromHeaders:headers key:kRewardedVideoCurrencyAmountHeaderKey];
+            NSNumber *currencyAmount = [self adAmountFromHeaders:headers key:kMPRewardedVideoCurrencyAmountHeaderKey];
             if (currencyAmount.integerValue <= 0) {
                 currencyAmount = @(kMPRewardedVideoRewardCurrencyAmountUnspecified);
             }
@@ -213,18 +213,18 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
             self.selectedReward = reward;
         }
 
-        self.rewardedVideoCompletionUrl = [headers objectForKey:kRewardedVideoCompletionUrlHeaderKey];
+        self.rewardedVideoCompletionUrl = [headers objectForKey:kMPRewardedVideoCompletionUrlHeaderKey];
 
         // rewarded playables
-        self.rewardedPlayableDuration = [self timeIntervalFromHeaders:headers forKey:kRewardedPlayableDurationHeaderKey];
-        self.rewardedPlayableShouldRewardOnClick = [[headers objectForKey:kRewardedPlayableRewardOnClickHeaderKey] boolValue];
+        self.rewardedPlayableDuration = [self timeIntervalFromHeaders:headers forKey:kMPRewardedPlayableDurationHeaderKey];
+        self.rewardedPlayableShouldRewardOnClick = [[headers objectForKey:kMPRewardedPlayableRewardOnClickHeaderKey] boolValue];
 
         // clickthrough experiment
-        self.clickthroughExperimentBrowserAgent = [self clickthroughExperimentVariantFromHeaders:headers forKey:kClickthroughExperimentBrowserAgent];
+        self.clickthroughExperimentBrowserAgent = [self clickthroughExperimentVariantFromHeaders:headers forKey:kMPClickthroughExperimentBrowserAgent];
         [MOPUBExperimentProvider setDisplayAgentFromAdServer:self.clickthroughExperimentBrowserAgent];
 
         // viewability
-        NSString * disabledViewabilityValue = [headers objectForKey:kViewabilityDisableHeaderKey];
+        NSString * disabledViewabilityValue = [headers objectForKey:kMPViewabilityDisableHeaderKey];
         NSNumber * disabledViewabilityVendors = disabledViewabilityValue != nil ? [disabledViewabilityValue safeIntegerValue] : nil;
         if (disabledViewabilityVendors != nil &&
             [disabledViewabilityVendors integerValue] >= MPViewabilityOptionNone &&
@@ -238,7 +238,7 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
 - (Class)setUpCustomEventClassFromHeaders:(NSDictionary *)headers
 {
-    NSString *customEventClassName = [headers objectForKey:kCustomEventClassNameHeaderKey];
+    NSString *customEventClassName = [headers objectForKey:kMPCustomEventClassNameHeaderKey];
 
     NSMutableDictionary *convertedCustomEvents = [NSMutableDictionary dictionary];
     if (self.adType == MPAdTypeBanner) {
@@ -273,9 +273,9 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
 - (NSDictionary *)customEventClassDataFromHeaders:(NSDictionary *)headers
 {
-    NSDictionary *result = [self dictionaryFromHeaders:headers forKey:kCustomEventClassDataHeaderKey];
+    NSDictionary *result = [self dictionaryFromHeaders:headers forKey:kMPCustomEventClassDataHeaderKey];
     if (!result) {
-        result = [self dictionaryFromHeaders:headers forKey:kNativeSDKParametersHeaderKey];
+        result = [self dictionaryFromHeaders:headers forKey:kMPNativeSDKParametersHeaderKey];
     }
     return result;
 }
@@ -305,12 +305,12 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
 - (MPAdType)adTypeFromHeaders:(NSDictionary *)headers
 {
-    NSString *adTypeString = [headers objectForKey:kAdTypeHeaderKey];
+    NSString *adTypeString = [headers objectForKey:kMPAdTypeHeaderKey];
 
     if ([adTypeString isEqualToString:@"interstitial"] || [adTypeString isEqualToString:@"rewarded_video"] || [adTypeString isEqualToString:@"rewarded_playable"]) {
         return MPAdTypeInterstitial;
     } else if (adTypeString &&
-               [headers objectForKey:kOrientationTypeHeaderKey]) {
+               [headers objectForKey:kMPOrientationTypeHeaderKey]) {
         return MPAdTypeInterstitial;
     } else if (adTypeString) {
         return MPAdTypeBanner;
@@ -321,9 +321,9 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
 - (NSString *)networkTypeFromHeaders:(NSDictionary *)headers
 {
-    NSString *adTypeString = [headers objectForKey:kAdTypeHeaderKey];
+    NSString *adTypeString = [headers objectForKey:kMPAdTypeHeaderKey];
     if ([adTypeString isEqualToString:@"interstitial"]) {
-        return [headers objectForKey:kInterstitialAdTypeHeaderKey];
+        return [headers objectForKey:kMPInterstitialAdTypeHeaderKey];
     } else {
         return adTypeString;
     }
@@ -347,7 +347,7 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
 - (NSTimeInterval)refreshIntervalFromHeaders:(NSDictionary *)headers
 {
-    NSString *intervalString = [headers objectForKey:kRefreshTimeHeaderKey];
+    NSString *intervalString = [headers objectForKey:kMPRefreshTimeHeaderKey];
     NSTimeInterval interval = -1;
     if (intervalString) {
         interval = [intervalString doubleValue];
@@ -420,7 +420,7 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 
 - (MPInterstitialOrientationType)orientationTypeFromHeaders:(NSDictionary *)headers
 {
-    NSString *orientation = [headers objectForKey:kOrientationTypeHeaderKey];
+    NSString *orientation = [headers objectForKey:kMPOrientationTypeHeaderKey];
     if ([orientation isEqualToString:@"p"]) {
         return MPInterstitialOrientationTypePortrait;
     } else if ([orientation isEqualToString:@"l"]) {
@@ -438,8 +438,8 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
         return nil;
     }
     NSMutableDictionary *videoTrackerDict = [NSMutableDictionary new];
-    NSArray *events = dictFromHeader[kNativeVideoTrackerEventsHeaderKey];
-    NSArray *urls = dictFromHeader[kNativeVideoTrackerUrlsHeaderKey];
+    NSArray *events = dictFromHeader[kMPNativeVideoTrackerEventsHeaderKey];
+    NSArray *urls = dictFromHeader[kMPNativeVideoTrackerUrlsHeaderKey];
     NSSet *supportedEvents = [NSSet setWithObjects:MPVASTTrackingEventTypeStart, MPVASTTrackingEventTypeFirstQuartile, MPVASTTrackingEventTypeMidpoint,  MPVASTTrackingEventTypeThirdQuartile, MPVASTTrackingEventTypeComplete, nil];
     for (NSString *event in events) {
         if (![supportedEvents containsObject:event]) {
@@ -456,9 +456,9 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 - (void)setVideoTrackers:(NSMutableDictionary *)videoTrackerDict event:(NSString *)event urls:(NSArray *)urls {
     NSMutableArray *trackers = [NSMutableArray new];
     for (NSString *url in urls) {
-        if ([url rangeOfString:kNativeVideoTrackerUrlMacro].location != NSNotFound) {
-            NSString *trackerUrl = [url stringByReplacingOccurrencesOfString:kNativeVideoTrackerUrlMacro withString:event];
-            NSDictionary *dict = @{kNativeVideoTrackerEventDictionaryKey:event, kNativeVideoTrackerTextDictionaryKey:trackerUrl};
+        if ([url rangeOfString:kMPNativeVideoTrackerUrlMacro].location != NSNotFound) {
+            NSString *trackerUrl = [url stringByReplacingOccurrencesOfString:kMPNativeVideoTrackerUrlMacro withString:event];
+            NSDictionary *dict = @{kMPNativeVideoTrackerEventDictionaryKey:event, kMPNativeVideoTrackerTextDictionaryKey:trackerUrl};
             MPVASTTrackingEvent *tracker = [[MPVASTTrackingEvent alloc] initWithDictionary:dict];
             [trackers addObject:tracker];
         }
@@ -473,7 +473,7 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
 - (NSArray *)parseAvailableRewardsFromHeaders:(NSDictionary *)headers {
     // The X-Rewarded-Currencies header key doesn't exist. This is probably
     // not a rewarded ad.
-    NSDictionary * currencies = [self dictionaryFromHeaders:headers forKey:kRewardedCurrenciesHeaderKey];
+    NSDictionary * currencies = [self dictionaryFromHeaders:headers forKey:kMPRewardedCurrenciesHeaderKey];
     if (currencies == nil) {
         return nil;
     }
@@ -506,7 +506,7 @@ NSString * const kViewabilityDisableHeaderKey = @"X-Disable-Viewability";
     if (variantString) {
         int parsedInt = -1;
         BOOL isNumber = [[NSScanner scannerWithString:variantString] scanInt:&parsedInt];
-        if (isNumber && parsedInt >= 0 && parsedInt <= kMaximumVariantForClickthroughExperiment) {
+        if (isNumber && parsedInt >= 0 && parsedInt <= kMPMaximumVariantForClickthroughExperiment) {
             variant = parsedInt;
         }
     }

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
@@ -139,7 +139,7 @@
         return;
     }
 
-    if ([self.configuration.networkType isEqualToString:kAdTypeClear]) {
+    if ([self.configuration.networkType isEqualToString:kMPAdTypeClear]) {
         MPLogInfo(kMPClearErrorLogFormatWithAdUnitID, self.delegate.interstitialAdController.adUnitId);
         self.loading = NO;
         [self.delegate manager:self didFailToLoadInterstitialWithError:[MOPUBError errorWithCode:MOPUBErrorNoInventory]];

--- a/MoPubSDK/Native Ads/MPNativeAdRequest.m
+++ b/MoPubSDK/Native Ads/MPNativeAdRequest.m
@@ -236,7 +236,7 @@
         return;
     }
 
-    if ([configuration.networkType isEqualToString:kAdTypeClear]) {
+    if ([configuration.networkType isEqualToString:kMPAdTypeClear]) {
         MPLogInfo(kMPClearErrorLogFormatWithAdUnitID, self.adUnitIdentifier);
         [self completeAdRequestWithAdObject:nil error:MPNativeAdNSErrorForNoInventory()];
         return;

--- a/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
+++ b/MoPubSDK/RewardedVideo/Internal/MPRewardedVideoAdManager.m
@@ -187,7 +187,7 @@
         return;
     }
 
-    if ([self.configuration.networkType isEqualToString:kAdTypeClear]) {
+    if ([self.configuration.networkType isEqualToString:kMPAdTypeClear]) {
         MPLogInfo(kMPClearErrorLogFormatWithAdUnitID, self.adUnitID);
         self.loading = NO;
         NSError *error = [NSError errorWithDomain:MoPubRewardedVideoAdsSDKDomain code:MPRewardedVideoAdErrorNoAdsAvailable userInfo:nil];

--- a/MoPubSDKTests/MOPUBExperimentProviderTests.m
+++ b/MoPubSDKTests/MOPUBExperimentProviderTests.m
@@ -27,7 +27,7 @@
 
 - (void)testClickthroughExperimentInApp {
     [MOPUBExperimentProvider setDisplayAgentOverriddenByClientFlag:NO];
-    NSDictionary * headers = @{ kClickthroughExperimentBrowserAgent: @"0"};
+    NSDictionary * headers = @{ kMPClickthroughExperimentBrowserAgent: @"0"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertEqual(config.clickthroughExperimentBrowserAgent, MOPUBDisplayAgentTypeInApp);
     XCTAssertEqual([MOPUBExperimentProvider displayAgentType], MOPUBDisplayAgentTypeInApp);
@@ -35,7 +35,7 @@
 
 - (void)testClickthroughExperimentNativeBrowser {
     [MOPUBExperimentProvider setDisplayAgentOverriddenByClientFlag:NO];
-    NSDictionary * headers = @{ kClickthroughExperimentBrowserAgent: @"1"};
+    NSDictionary * headers = @{ kMPClickthroughExperimentBrowserAgent: @"1"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertEqual(config.clickthroughExperimentBrowserAgent, MOPUBDisplayAgentTypeNativeSafari);
     XCTAssertEqual([MOPUBExperimentProvider displayAgentType], MOPUBDisplayAgentTypeNativeSafari);
@@ -43,7 +43,7 @@
 
 - (void)testClickthroughExperimentSafariViewController {
     [MOPUBExperimentProvider setDisplayAgentOverriddenByClientFlag:NO];
-    NSDictionary * headers = @{ kClickthroughExperimentBrowserAgent: @"2"};
+    NSDictionary * headers = @{ kMPClickthroughExperimentBrowserAgent: @"2"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertEqual(config.clickthroughExperimentBrowserAgent, MOPUBDisplayAgentTypeSafariViewController);
     XCTAssertEqual([MOPUBExperimentProvider displayAgentType], MOPUBDisplayAgentTypeSafariViewController);
@@ -52,7 +52,7 @@
 - (void)testClickthroughClientOverride {
     [[MoPub sharedInstance] setClickthroughDisplayAgentType:MOPUBDisplayAgentTypeInApp];
 
-    NSDictionary * headers = @{ kClickthroughExperimentBrowserAgent: @"2"};
+    NSDictionary * headers = @{ kMPClickthroughExperimentBrowserAgent: @"2"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertEqual(config.clickthroughExperimentBrowserAgent, MOPUBDisplayAgentTypeSafariViewController);
 

--- a/MoPubSDKTests/MPAdConfigurationFactory.m
+++ b/MoPubSDKTests/MPAdConfigurationFactory.m
@@ -20,9 +20,9 @@
 + (NSMutableDictionary *)defaultNativeAdHeaders
 {
     return [@{
-              kAdTypeHeaderKey: kAdTypeNative,
-              kFailUrlHeaderKey: @"http://ads.mopub.com/m/failURL",
-              kRefreshTimeHeaderKey: @"61",
+              kMPAdTypeHeaderKey: kMPAdTypeNative,
+              kMPFailUrlHeaderKey: @"http://ads.mopub.com/m/failURL",
+              kMPRefreshTimeHeaderKey: @"61",
               } mutableCopy];
 }
 
@@ -46,15 +46,15 @@
 
 + (MPAdConfiguration *)defaultNativeAdConfigurationWithNetworkType:(NSString *)type
 {
-    return [self defaultNativeAdConfigurationWithHeaders:@{kAdTypeHeaderKey: type}
+    return [self defaultNativeAdConfigurationWithHeaders:@{kMPAdTypeHeaderKey: type}
                                               properties:nil];
 }
 
 + (MPAdConfiguration *)defaultNativeAdConfigurationWithCustomEventClassName:(NSString *)eventClassName
 {
     return [MPAdConfigurationFactory defaultNativeAdConfigurationWithHeaders:@{
-                                                                               kCustomEventClassNameHeaderKey: eventClassName,
-                                                                               kAdTypeHeaderKey: @"custom"}
+                                                                               kMPCustomEventClassNameHeaderKey: eventClassName,
+                                                                               kMPAdTypeHeaderKey: @"custom"}
                                                                   properties:nil];
 }
 
@@ -78,15 +78,15 @@
 + (NSMutableDictionary *)defaultBannerHeaders
 {
     return [@{
-              kAdTypeHeaderKey: kAdTypeHtml,
-              kClickthroughHeaderKey: @"http://ads.mopub.com/m/clickThroughTracker?a=1",
-              kFailUrlHeaderKey: @"http://ads.mopub.com/m/failURL",
-              kHeightHeaderKey: @"50",
-              kImpressionTrackerHeaderKey: @"http://ads.mopub.com/m/impressionTracker",
-              kInterceptLinksHeaderKey: @"1",
-              kLaunchpageHeaderKey: @"http://publisher.com",
-              kRefreshTimeHeaderKey: @"30",
-              kWidthHeaderKey: @"320"
+              kMPAdTypeHeaderKey: kMPAdTypeHtml,
+              kMPClickthroughHeaderKey: @"http://ads.mopub.com/m/clickThroughTracker?a=1",
+              kMPFailUrlHeaderKey: @"http://ads.mopub.com/m/failURL",
+              kMPHeightHeaderKey: @"50",
+              kMPImpressionTrackerHeaderKey: @"http://ads.mopub.com/m/impressionTracker",
+              kMPInterceptLinksHeaderKey: @"1",
+              kMPLaunchpageHeaderKey: @"http://publisher.com",
+              kMPRefreshTimeHeaderKey: @"30",
+              kMPWidthHeaderKey: @"320"
               } mutableCopy];
 }
 
@@ -97,15 +97,15 @@
 
 + (MPAdConfiguration *)defaultBannerConfigurationWithNetworkType:(NSString *)type
 {
-    return [self defaultBannerConfigurationWithHeaders:@{kAdTypeHeaderKey: type}
+    return [self defaultBannerConfigurationWithHeaders:@{kMPAdTypeHeaderKey: type}
                                             HTMLString:nil];
 }
 
 + (MPAdConfiguration *)defaultBannerConfigurationWithCustomEventClassName:(NSString *)eventClassName
 {
     return [MPAdConfigurationFactory defaultBannerConfigurationWithHeaders:@{
-                                                                             kCustomEventClassNameHeaderKey: eventClassName,
-                                                                             kAdTypeHeaderKey: @"custom"}
+                                                                             kMPCustomEventClassNameHeaderKey: eventClassName,
+                                                                             kMPAdTypeHeaderKey: @"custom"}
                                                                 HTMLString:nil];
 }
 
@@ -127,14 +127,14 @@
 + (NSMutableDictionary *)defaultInterstitialHeaders
 {
     return [@{
-              kAdTypeHeaderKey: kAdTypeInterstitial,
-              kClickthroughHeaderKey: @"http://ads.mopub.com/m/clickThroughTracker?a=1",
-              kFailUrlHeaderKey: @"http://ads.mopub.com/m/failURL",
-              kImpressionTrackerHeaderKey: @"http://ads.mopub.com/m/impressionTracker",
-              kInterceptLinksHeaderKey: @"1",
-              kLaunchpageHeaderKey: @"http://publisher.com",
-              kInterstitialAdTypeHeaderKey: kAdTypeHtml,
-              kOrientationTypeHeaderKey: @"p"
+              kMPAdTypeHeaderKey: kMPAdTypeInterstitial,
+              kMPClickthroughHeaderKey: @"http://ads.mopub.com/m/clickThroughTracker?a=1",
+              kMPFailUrlHeaderKey: @"http://ads.mopub.com/m/failURL",
+              kMPImpressionTrackerHeaderKey: @"http://ads.mopub.com/m/impressionTracker",
+              kMPInterceptLinksHeaderKey: @"1",
+              kMPLaunchpageHeaderKey: @"http://publisher.com",
+              kMPInterstitialAdTypeHeaderKey: kMPAdTypeHtml,
+              kMPOrientationTypeHeaderKey: @"p"
               } mutableCopy];
 }
 
@@ -146,8 +146,8 @@
 + (MPAdConfiguration *)defaultMRAIDInterstitialConfiguration
 {
     NSDictionary *headers = @{
-                              kAdTypeHeaderKey: @"mraid",
-                              kOrientationTypeHeaderKey: @"p"
+                              kMPAdTypeHeaderKey: @"mraid",
+                              kMPOrientationTypeHeaderKey: @"p"
                               };
 
     return [self defaultInterstitialConfigurationWithHeaders:headers
@@ -175,15 +175,15 @@
 
 + (MPAdConfiguration *)defaultInterstitialConfigurationWithNetworkType:(NSString *)type
 {
-    return [self defaultInterstitialConfigurationWithHeaders:@{kInterstitialAdTypeHeaderKey: type}
+    return [self defaultInterstitialConfigurationWithHeaders:@{kMPInterstitialAdTypeHeaderKey: type}
                                                   HTMLString:nil];
 }
 
 + (MPAdConfiguration *)defaultInterstitialConfigurationWithCustomEventClassName:(NSString *)eventClassName
 {
     return [MPAdConfigurationFactory defaultInterstitialConfigurationWithHeaders:@{
-                                                                                   kCustomEventClassNameHeaderKey: eventClassName,
-                                                                                   kInterstitialAdTypeHeaderKey: @"custom"}
+                                                                                   kMPCustomEventClassNameHeaderKey: eventClassName,
+                                                                                   kMPInterstitialAdTypeHeaderKey: @"custom"}
                                                                       HTMLString:nil];
 }
 
@@ -203,28 +203,28 @@
 + (NSMutableDictionary *)defaultRewardedVideoHeaders
 {
     return [@{
-              kAdTypeHeaderKey: @"custom",
-              kClickthroughHeaderKey: @"http://ads.mopub.com/m/clickThroughTracker?a=1",
-              kFailUrlHeaderKey: @"http://ads.mopub.com/m/failURL",
-              kImpressionTrackerHeaderKey: @"http://ads.mopub.com/m/impressionTracker",
-              kInterceptLinksHeaderKey: @"1",
-              kLaunchpageHeaderKey: @"http://publisher.com",
-              kInterstitialAdTypeHeaderKey: kAdTypeHtml,
+              kMPAdTypeHeaderKey: @"custom",
+              kMPClickthroughHeaderKey: @"http://ads.mopub.com/m/clickThroughTracker?a=1",
+              kMPFailUrlHeaderKey: @"http://ads.mopub.com/m/failURL",
+              kMPImpressionTrackerHeaderKey: @"http://ads.mopub.com/m/impressionTracker",
+              kMPInterceptLinksHeaderKey: @"1",
+              kMPLaunchpageHeaderKey: @"http://publisher.com",
+              kMPInterstitialAdTypeHeaderKey: kMPAdTypeHtml,
               } mutableCopy];
 }
 
 + (NSMutableDictionary *)defaultRewardedVideoHeadersWithReward
 {
     NSMutableDictionary *dict = [[self defaultRewardedVideoHeaders] mutableCopy];
-    dict[kRewardedVideoCurrencyNameHeaderKey] = @"gold";
-    dict[kRewardedVideoCurrencyAmountHeaderKey] = @"12";
+    dict[kMPRewardedVideoCurrencyNameHeaderKey] = @"gold";
+    dict[kMPRewardedVideoCurrencyAmountHeaderKey] = @"12";
     return dict;
 }
 
 + (NSMutableDictionary *)defaultRewardedVideoHeadersServerToServer
 {
     NSMutableDictionary *dict = [[self defaultRewardedVideoHeaders] mutableCopy];
-    dict[kRewardedVideoCompletionUrlHeaderKey] = @"http://ads.mopub.com/m/rewarded_video_completion?req=332dbe5798d644309d9d950321d37e3c&reqt=1460590468.0&id=54c94899972a4d4fb00c9cbf0fd08141&cid=303d4529ee3b42e7ac1f5c19caf73515&udid=ifa%3A3E67D059-6F94-4C88-AD2A-72539FE13795&cppck=09CCC";
+    dict[kMPRewardedVideoCompletionUrlHeaderKey] = @"http://ads.mopub.com/m/rewarded_video_completion?req=332dbe5798d644309d9d950321d37e3c&reqt=1460590468.0&id=54c94899972a4d4fb00c9cbf0fd08141&cid=303d4529ee3b42e7ac1f5c19caf73515&udid=ifa%3A3E67D059-6F94-4C88-AD2A-72539FE13795&cppck=09CCC";
     return dict;
 }
 

--- a/MoPubSDKTests/MPAdConfigurationTests.m
+++ b/MoPubSDKTests/MPAdConfigurationTests.m
@@ -28,7 +28,7 @@
 #pragma mark - Rewarded Ads
 
 - (void)testRewardedPlayableDurationParseSuccess {
-    NSDictionary * headers = @{ kRewardedPlayableDurationHeaderKey: @"30" };
+    NSDictionary * headers = @{ kMPRewardedPlayableDurationHeaderKey: @"30" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertEqual(config.rewardedPlayableDuration, 30);
@@ -42,7 +42,7 @@
 }
 
 - (void)testRewardedPlayableRewardOnClickParseSuccess {
-    NSDictionary * headers = @{ kRewardedPlayableRewardOnClickHeaderKey: @"true" };
+    NSDictionary * headers = @{ kMPRewardedPlayableRewardOnClickHeaderKey: @"true" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertEqual(config.rewardedPlayableShouldRewardOnClick, true);
@@ -56,8 +56,8 @@
 }
 
 - (void)testRewardedSingleCurrencyParseSuccess {
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
                                };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -77,7 +77,7 @@
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config.availableRewards);
@@ -92,7 +92,7 @@
     // {
     //   "rewards": []
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config.availableRewards);
@@ -107,7 +107,7 @@
     // {
     //   "rewards": [ { "n": "Coins", "a": 8 } ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"n\": \"Coins\", \"a\": 8 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"n\": \"Coins\", \"a\": 8 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config.availableRewards);
@@ -119,9 +119,9 @@
 }
 
 - (void)testRewardedMultiCurrencyParseFailoverToSingleCurrencySuccess {
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
-                                kRewardedCurrenciesHeaderKey: @"{ }"
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
+                                kMPRewardedCurrenciesHeaderKey: @"{ }"
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -165,21 +165,21 @@
 }
 
 - (void)testClickthroughExperimentInApp {
-    NSDictionary * headers = @{ kClickthroughExperimentBrowserAgent: @"0"};
+    NSDictionary * headers = @{ kMPClickthroughExperimentBrowserAgent: @"0"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertEqual(config.clickthroughExperimentBrowserAgent, MOPUBDisplayAgentTypeInApp);
     XCTAssertEqual([MOPUBExperimentProvider displayAgentType], MOPUBDisplayAgentTypeInApp);
 }
 
 - (void)testClickthroughExperimentNativeBrowser {
-    NSDictionary * headers = @{ kClickthroughExperimentBrowserAgent: @"1"};
+    NSDictionary * headers = @{ kMPClickthroughExperimentBrowserAgent: @"1"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertEqual(config.clickthroughExperimentBrowserAgent, MOPUBDisplayAgentTypeNativeSafari);
     XCTAssertEqual([MOPUBExperimentProvider displayAgentType], MOPUBDisplayAgentTypeNativeSafari);
 }
 
 - (void)testClickthroughExperimentSafariViewController {
-    NSDictionary * headers = @{ kClickthroughExperimentBrowserAgent: @"2"};
+    NSDictionary * headers = @{ kMPClickthroughExperimentBrowserAgent: @"2"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertEqual(config.clickthroughExperimentBrowserAgent, MOPUBDisplayAgentTypeSafariViewController);
     XCTAssertEqual([MOPUBExperimentProvider displayAgentType], MOPUBDisplayAgentTypeSafariViewController);
@@ -194,7 +194,7 @@
     // {
     //   "X-Disable-Viewability": 3
     // }
-    NSDictionary * headers = @{ kViewabilityDisableHeaderKey: @"3" };
+    NSDictionary * headers = @{ kMPViewabilityDisableHeaderKey: @"3" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config);
@@ -210,7 +210,7 @@
     // {
     //   "X-Disable-Viewability": 0
     // }
-    NSDictionary * headers = @{ kViewabilityDisableHeaderKey: @"0" };
+    NSDictionary * headers = @{ kMPViewabilityDisableHeaderKey: @"0" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config);
@@ -226,7 +226,7 @@
     // {
     //   "X-Disable-Viewability": 3
     // }
-    NSDictionary * headers = @{ kViewabilityDisableHeaderKey: @"3" };
+    NSDictionary * headers = @{ kMPViewabilityDisableHeaderKey: @"3" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config);
@@ -241,7 +241,7 @@
     // {
     //   "X-Disable-Viewability": 0
     // }
-    headers = @{ kViewabilityDisableHeaderKey: @"0" };
+    headers = @{ kMPViewabilityDisableHeaderKey: @"0" };
     config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config);
@@ -257,7 +257,7 @@
     // {
     //   "X-Disable-Viewability": 3aaaa
     // }
-    NSDictionary * headers = @{ kViewabilityDisableHeaderKey: @"3aaaa" };
+    NSDictionary * headers = @{ kMPViewabilityDisableHeaderKey: @"3aaaa" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config);
@@ -273,7 +273,7 @@
     // {
     //   "X-Disable-Viewability": ""
     // }
-    NSDictionary * headers = @{ kViewabilityDisableHeaderKey: @"" };
+    NSDictionary * headers = @{ kMPViewabilityDisableHeaderKey: @"" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     XCTAssertNotNil(config);
@@ -329,14 +329,14 @@
 #pragma mark - Banner Impression Headers
 
 - (void)testVisibleImpressionHeader {
-    NSDictionary * headers = @{ kBannerImpressionVisableMsHeaderKey: @"0", kBannerImpressionMinPixelHeaderKey:@"1"};
+    NSDictionary * headers = @{ kMPBannerImpressionVisableMsHeaderKey: @"0", kMPBannerImpressionMinPixelHeaderKey:@"1"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertEqual(config.impressionMinVisiblePixels, 1);
     XCTAssertEqual(config.impressionMinVisibleTimeInSec, 0);
 }
 
 - (void)testVisibleImpressionEnabled {
-    NSDictionary * headers = @{ kBannerImpressionVisableMsHeaderKey: @"0", kBannerImpressionMinPixelHeaderKey:@"1"};
+    NSDictionary * headers = @{ kMPBannerImpressionVisableMsHeaderKey: @"0", kMPBannerImpressionMinPixelHeaderKey:@"1"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertTrue(config.visibleImpressionTrackingEnabled);
 }
@@ -348,7 +348,7 @@
 }
 
 - (void)testVisibleImpressionNotEnabled {
-    NSDictionary * headers = @{kBannerImpressionVisableMsHeaderKey: @"0", kBannerImpressionMinPixelHeaderKey:@"0"};
+    NSDictionary * headers = @{kMPBannerImpressionVisableMsHeaderKey: @"0", kMPBannerImpressionMinPixelHeaderKey:@"0"};
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
     XCTAssertFalse(config.visibleImpressionTrackingEnabled);
 }

--- a/MoPubSDKTests/MPBannerCustomEventAdapterTests.m
+++ b/MoPubSDKTests/MPBannerCustomEventAdapterTests.m
@@ -30,7 +30,7 @@
 
 // When an AD is in the imp tracking experiment, banner impressions (include all banner formats) are fired from SDK.
 - (void)testShouldTrackImpOnDisplayWhenExperimentEnabled {
-    NSDictionary *headers = @{ kBannerImpressionVisableMsHeaderKey: @"0", kBannerImpressionMinPixelHeaderKey:@"1"};
+    NSDictionary *headers = @{ kMPBannerImpressionVisableMsHeaderKey: @"0", kMPBannerImpressionMinPixelHeaderKey:@"1"};
     MPAdConfiguration *config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     MPBannerCustomEventAdapter *adapter = [MPBannerCustomEventAdapter new];

--- a/MoPubSDKTests/MPRewardedVideoAdManagerTests.m
+++ b/MoPubSDKTests/MPRewardedVideoAdManagerTests.m
@@ -26,8 +26,8 @@ static const NSTimeInterval kTestTimeout   = 2; // seconds
 
 - (void)testRewardedSingleCurrencyPresentationSuccess {
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -61,7 +61,7 @@ static const NSTimeInterval kTestTimeout   = 2; // seconds
     //     { "name": "Coins", "amount": 8 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -96,7 +96,7 @@ static const NSTimeInterval kTestTimeout   = 2; // seconds
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -131,7 +131,7 @@ static const NSTimeInterval kTestTimeout   = 2; // seconds
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -173,7 +173,7 @@ static const NSTimeInterval kTestTimeout   = 2; // seconds
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -215,7 +215,7 @@ static const NSTimeInterval kTestTimeout   = 2; // seconds
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.

--- a/MoPubSDKTests/MPRewardedVideoTests.m
+++ b/MoPubSDKTests/MPRewardedVideoTests.m
@@ -46,8 +46,8 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
 
 - (void)testRewardedSingleCurrencyPresentationSuccess {
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -79,7 +79,7 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     //     { "name": "Coins", "amount": 8 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -110,8 +110,8 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     //     { "name": "Coins", "amount": 8 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
-                                kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 } ] }"
+    NSDictionary * headers = @{ kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+                                kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 } ] }"
                               };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -156,7 +156,7 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -190,7 +190,7 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -230,7 +230,7 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -270,7 +270,7 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
+    NSDictionary * headers = @{ kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }" };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
     // Semaphore to wait for asynchronous method to finish before continuing the test.
@@ -313,8 +313,8 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     //     { "name": "Energy", "amount": 20 }
     //   ]
     // }
-    NSDictionary * headers = @{ kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
-                                kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }"
+    NSDictionary * headers = @{ kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+                                kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }"
                               };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -351,7 +351,7 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
 }
 
 - (void)testRewardedS2SNoRewardSpecified {
-    NSDictionary * headers = @{ kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+    NSDictionary * headers = @{ kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -439,9 +439,9 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     NSString * customData = [@"" stringByPaddingToLength:512 withString:@"test" startingAtIndex:0];
 
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
-                                kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
+                                kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -474,9 +474,9 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     NSString * customData = [@"" stringByPaddingToLength:8200 withString:@"test" startingAtIndex:0];
 
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
-                                kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
+                                kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
                               };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -506,9 +506,9 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
 
 - (void)testCustomDataNil {
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
-                                kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
+                                kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -536,9 +536,9 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
 
 - (void)testCustomDataEmpty {
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
-                                kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
+                                kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -569,9 +569,9 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     NSString * customData = @"{ \"key\": \"some value with spaces\" }";
 
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
-                                kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
+                                kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -605,8 +605,8 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
     NSString * customData = [@"" stringByPaddingToLength:512 withString:@"test" startingAtIndex:0];
 
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
+    NSDictionary * headers = @{ kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -645,10 +645,10 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
 
 - (void)testNetworkIdentifierInRewardCallback {
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kCustomEventClassNameHeaderKey: @"MPMockChartboostRewardedVideoCustomEvent",
-                                kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
-                                kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+    NSDictionary * headers = @{ kMPCustomEventClassNameHeaderKey: @"MPMockChartboostRewardedVideoCustomEvent",
+                                kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
+                                kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 
@@ -676,11 +676,11 @@ static MPRewardedVideoDelegateHandler * delegateHandler = nil;
 
 - (void)testMoPubNetworkIdentifierInRewardCallback {
     // Setup rewarded ad configuration
-    NSDictionary * headers = @{ kAdTypeHeaderKey: @"rewarded_video",
-                                kCustomEventClassNameHeaderKey: @"rewarded_video",
-                                kRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
-                                kRewardedVideoCurrencyAmountHeaderKey: @"3",
-                                kRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
+    NSDictionary * headers = @{ kMPAdTypeHeaderKey: @"rewarded_video",
+                                kMPCustomEventClassNameHeaderKey: @"rewarded_video",
+                                kMPRewardedVideoCurrencyNameHeaderKey: @"Diamonds",
+                                kMPRewardedVideoCurrencyAmountHeaderKey: @"3",
+                                kMPRewardedVideoCompletionUrlHeaderKey: @"https://test.com?verifier=123",
                                 };
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
 

--- a/MoPubSDKTests/MoPubTests.m
+++ b/MoPubSDKTests/MoPubTests.m
@@ -136,9 +136,9 @@ static NSTimeInterval const kTestTimeout = 2;
     [MoPub sharedInstance].forceWKWebView = NO;
 
     // Verify that UIWebView was used instead of WKWebView for video ads
-    NSDictionary * headers = @{ kAdTypeHeaderKey: @"rewarded_video",
-                                kIsVastVideoPlayerKey: @(1),
-                                kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }"
+    NSDictionary * headers = @{ kMPAdTypeHeaderKey: @"rewarded_video",
+                                kMPIsVastVideoPlayerKey: @(1),
+                                kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }"
                                 };
 
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];
@@ -155,9 +155,9 @@ static NSTimeInterval const kTestTimeout = 2;
     [MoPub sharedInstance].forceWKWebView = YES;
 
     // Verify that WKWebView was used instead of UIWebView for video ads
-    NSDictionary * headers = @{ kAdTypeHeaderKey: @"rewarded_video",
-                                kIsVastVideoPlayerKey: @(1),
-                                kRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }"
+    NSDictionary * headers = @{ kMPAdTypeHeaderKey: @"rewarded_video",
+                                kMPIsVastVideoPlayerKey: @(1),
+                                kMPRewardedCurrenciesHeaderKey: @"{ \"rewards\": [ { \"name\": \"Coins\", \"amount\": 8 }, { \"name\": \"Diamonds\", \"amount\": 1 }, { \"name\": \"Energy\", \"amount\": 20 } ] }"
                                 };
 
     MPAdConfiguration * config = [[MPAdConfiguration alloc] initWithHeaders:headers data:nil];


### PR DESCRIPTION
A symbol conflict has occurred in a project using mopub and another library. 
(Conflicted symbols: `_kHeightHeaderKey`, `_kWidthHeaderKey`)

![image 2018-05-08 15-09-32](https://user-images.githubusercontent.com/6250288/39741279-43e7e5ce-52d4-11e8-8bb1-ccb48e1ed30f.png)

These (and other const values) should be prefixed to avoid symbol collisions.

Related PR:  Prefixes kReachabilityChangedNotification to eliminate symbol collisions. #146
