### PR TITLE
Utilizing up-to-date keywords for banner ad manager's refresh

### DIFF
--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -175,7 +175,7 @@
     [self.communicator cancel];
 
     URL = (URL) ? URL : [MPAdServerURLBuilder URLWithAdUnitID:[self.delegate adUnitId]
-                                                     keywords:self.targeting.keywords
+                                                     keywords:[self.delegate currentKeywords]
                                              userDataKeywords:self.targeting.userDataKeywords
                                                      location:self.targeting.location];
 

--- a/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
@@ -18,6 +18,7 @@
 - (MPAdView *)banner;
 - (id<MPAdViewDelegate>)bannerDelegate;
 - (CGSize)containerSize;
+- (NSString *)currentKeywords;
 - (UIViewController *)viewControllerForPresentingModalView;
 
 - (void)invalidateContentView;

--- a/MoPubSDK/MPAdView.m
+++ b/MoPubSDK/MPAdView.m
@@ -140,6 +140,11 @@
     return self.originalSize;
 }
 
+- (NSString *)currentKeywords
+{
+    return self.keywords;
+}
+
 - (UIViewController *)viewControllerForPresentingModalView
 {
     return [self.delegate viewControllerForPresentingModalView];


### PR DESCRIPTION
MPAdView's banner refresh which is managed by MPBannerAdManager will use stale keywords for all subsequent refresh requests. This PR will grab the latest keywords assigned to MPAdView through MPBannerAdManagerDelegate protocol to be sent upon the refresh initiated by MPBannerAdManager.