### PR TITLE
Update targeting params on MPAdView autorefresh.

### DIFF
--- a/MoPubSDK/Internal/Banners/MPBannerAdManager.m
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManager.m
@@ -201,6 +201,7 @@
 - (void)refreshTimerDidFire
 {
     if (!self.loading && self.automaticallyRefreshesContents) {
+        self.targeting = [self.delegate targeting];
         [self loadAdWithTargeting:self.targeting];
     }
 }

--- a/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
+++ b/MoPubSDK/Internal/Banners/MPBannerAdManagerDelegate.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class MPAdView;
+@class MPAdTargeting;
 @protocol MPAdViewDelegate;
 
 @protocol MPBannerAdManagerDelegate <NSObject>
@@ -19,6 +20,7 @@
 - (id<MPAdViewDelegate>)bannerDelegate;
 - (CGSize)containerSize;
 - (UIViewController *)viewControllerForPresentingModalView;
+- (MPAdTargeting *)targeting;
 
 - (void)invalidateContentView;
 

--- a/MoPubSDK/MPAdView.m
+++ b/MoPubSDK/MPAdView.m
@@ -81,13 +81,7 @@
 
 - (void)loadAd
 {
-    MPAdTargeting * targeting = [[MPAdTargeting alloc] init];
-    targeting.keywords = self.keywords;
-    targeting.localExtras = self.localExtras;
-    targeting.location = self.location;
-    targeting.userDataKeywords = self.userDataKeywords;
-
-    [self.adManager loadAdWithTargeting:targeting];
+    [self.adManager loadAdWithTargeting:[self targeting]];
 }
 
 - (void)refreshAd
@@ -145,6 +139,16 @@
 - (UIViewController *)viewControllerForPresentingModalView
 {
     return [self.delegate viewControllerForPresentingModalView];
+}
+
+- (MPAdTargeting *)targeting
+{
+    MPAdTargeting *targeting = [[MPAdTargeting alloc] init];
+    targeting.keywords = self.keywords;
+    targeting.localExtras = self.localExtras;
+    targeting.location = self.location;
+    targeting.userDataKeywords = self.userDataKeywords;
+    return targeting;
 }
 
 - (void)invalidateContentView

--- a/MoPubSDKTests/MPBannerAdManagerDelegateHandler.h
+++ b/MoPubSDKTests/MPBannerAdManagerDelegateHandler.h
@@ -26,6 +26,7 @@ typedef void(^MPBannerAdManagerDelegateHandlerErrorBlock)(NSError * error);
 @property (nonatomic, copy) NSString * userDataKeywords;
 @property (nonatomic, strong) CLLocation * location;
 @property (nonatomic, strong) UIViewController * viewControllerForPresentingModalView;
+@property (nonatomic, strong) MPAdTargeting *targeting;
 
 @property (nonatomic, copy) MPBannerAdManagerDelegateHandlerBlock didLoadAd;
 @property (nonatomic, copy) MPBannerAdManagerDelegateHandlerErrorBlock didFailToLoadAd;


### PR DESCRIPTION
Currently MoPub `MPBannerAdManager` keeps a local copy of targeting parameters, which it uses on autorefresh. The current API makes it look like you can set new keywords and other targeting attributes on a `MPAdView` instance, and they would be used on the next ad autorefresh, but it doesn't work.
This fix makes `MPBannerAdManager` fetch an updated `MPAdTargeting` instance on every autorefresh tick prior to making a request.

This is useful for integrating with Amazon A9 while using MoPub's autorefresh, because `keywords` need to be updated on each ad request.

There's a similar existing pull request: https://github.com/mopub/mopub-ios-sdk/pull/270
My changes are actually based on it (so, kudos to @albzhu). The difference in this one is that all targeting parameters are updated, so it's more unified. 

It looks like you don't accept pull requests in this repository, but please consider making this change internally.
Thanks.