### PR TITLE
prevent crash for placer [MPTableViewAdPlacer adPlacer:didLoadAdAtIndexPath:] and [MPT…

### DIFF
--- a/MoPubSDK/NativeAds/MPTableViewAdPlacer.m
+++ b/MoPubSDK/NativeAds/MPTableViewAdPlacer.m
@@ -107,6 +107,12 @@ static NSString * const kTableViewAdPlacerReuseIdentifier = @"MPTableViewAdPlace
 
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didLoadAdAtIndexPath:(NSIndexPath *)indexPath
 {
+    NSInteger safeSectionNumber = [self.tableView.dataSource numberOfSectionsInTableView:self.tableView];
+    NSInteger safeRowNumber = [self.tableView.dataSource tableView:self.tableView numberOfRowsInSection:indexPath.section];
+    if(indexPath.section >= safeSectionNumber || indexPath.row >= safeRowNumber) {
+        return;
+    }
+    
     BOOL originalAnimationsEnabled = [UIView areAnimationsEnabled];
     //We only want to enable animations if the index path is before or within our visible cells
     BOOL animationsEnabled = ([(NSIndexPath *)[self.tableView.indexPathsForVisibleRows lastObject] compare:indexPath] != NSOrderedAscending) && originalAnimationsEnabled;
@@ -120,10 +126,19 @@ static NSString * const kTableViewAdPlacerReuseIdentifier = @"MPTableViewAdPlace
 
 - (void)adPlacer:(MPStreamAdPlacer *)adPlacer didRemoveAdsAtIndexPaths:(NSArray *)indexPaths
 {
+    NSMutableArray *targetIndexPaths = [[NSMutableArray alloc] init];
+    for (NSIndexPath *indexPath in indexPaths) {
+        if (indexPath.section < [self.tableView numberOfSections]) {
+            if (indexPath.row < [self.tableView numberOfRowsInSection:indexPath.section]) {
+                [targetIndexPaths addObject:indexPath];
+            }
+        }
+    }
+    
     BOOL originalAnimationsEnabled = [UIView areAnimationsEnabled];
     [UIView setAnimationsEnabled:NO];
     [self.tableView mp_beginUpdates];
-    [self.tableView deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationNone];
+    [self.tableView deleteRowsAtIndexPaths:targetIndexPaths withRowAnimation:UITableViewRowAnimationNone];
     [self.tableView mp_endUpdates];
     [UIView setAnimationsEnabled:originalAnimationsEnabled];
 }


### PR DESCRIPTION
Hi, I really want Mopub team can merge this PR.

When people use a single table with multiple dataSource (imagine a viewController with several segments, each segment representing a different dataSource), the MPTableViewAdPlacer will crash when ads returned during user switch segment.

XCode will throw "NSInternalInconsistencyException" if the Mopub placer insert/delete ads outside the valid range. (Below is crash log)
[https://lh3.googleusercontent.com/AiaUtQfDxK6z8aICFainoFtJ9fCibiqn66C4h1eYb2btJ99tSEOSbLOvBwVrTw41PylSa2hHRyxDvYFGHkMcxCX5sm328Rmd=s600
](https://lh3.googleusercontent.com/AiaUtQfDxK6z8aICFainoFtJ9fCibiqn66C4h1eYb2btJ99tSEOSbLOvBwVrTw41PylSa2hHRyxDvYFGHkMcxCX5sm328Rmd=s600
)

Crashlytics shows that this crash issue happened:
[https://lh3.googleusercontent.com/aTA6zLs4Fh2faY1umFlvuz5aN5yaYU5bI81FUMK83KZx7kgH5FYJ_zb5YzmszGr5HEDhYfEi9p4BjA0Wcsze3uJkLzLaZ3c=s600](https://lh3.googleusercontent.com/aTA6zLs4Fh2faY1umFlvuz5aN5yaYU5bI81FUMK83KZx7kgH5FYJ_zb5YzmszGr5HEDhYfEi9p4BjA0Wcsze3uJkLzLaZ3c=s600)

For now, whenever Mopub SDK updated. I have to pod install the SDK and patch this code into our project to prevent application from crash.

I really want this PR can be merged into Mopub SDK. Thanks.
