### PR TITLE
Enable DEFINE_MODULES

### DIFF
--- a/mopub-ios-sdk.podspec
+++ b/mopub-ios-sdk.podspec
@@ -37,6 +37,9 @@ Pod::Spec.new do |spec|
                             'WebKit'
                           ]
   spec.default_subspecs = 'MoPubSDK'
+  spec.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
 
   spec.subspec 'MoPubSDK' do |sdk|
     sdk.dependency              'mopub-ios-sdk/Core'


### PR DESCRIPTION
Currently, mopub-ios-sdk doesn't generate modulemap automatically on integrating via CocoaPods.

So we need to specify `use_modular_headers!` on CocoaPods to integrate to Swift project.

```ruby
pod 'mopub-ios-sdk', modular_headers: true
```

So I added setting to generate modulemap.

See Modular Headers section on this entry http://blog.cocoapods.org/CocoaPods-1.5.0/