### PR TITLE
Fix threading crashes

### DIFF
--- a/MoPubSDK/Internal/Utility/MPTimer.m
+++ b/MoPubSDK/Internal/Utility/MPTimer.m
@@ -50,7 +50,9 @@
     // a potential deadlock, scheduling to the main thread will be asynchronous
     // on the next main thread run loop.
     void (^mainThreadOperation)(void) = ^void(void) {
-        [NSRunLoop.mainRunLoop addTimer:timer.timer forMode:runLoopMode];
+        if(timer.timer.isValid) {
+            [NSRunLoop.mainRunLoop addTimer:timer.timer forMode:runLoopMode];
+        }
     };
 
     if ([NSThread isMainThread]) {


### PR DESCRIPTION
I just noticed that we never merged another fix in `MPTimer.m`. This PR takes care of streamlining the whole fork.