### PR TITLE
Remove `user_target_xcconfig` settings

### DIFF
--- a/mopub-ios-sdk.podspec
+++ b/mopub-ios-sdk.podspec
@@ -39,7 +39,6 @@ Pod::Spec.new do |spec|
   spec.default_subspecs = 'MoPubSDK'
 
   spec.pod_target_xcconfig  = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e armv7 armv7s', 'EXCLUDED_ARCHS[sdk=iphoneos*]' => 'i386 x86_64' }
-  spec.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e armv7 armv7s', 'EXCLUDED_ARCHS[sdk=iphoneos*]' => 'i386 x86_64' }
 
   spec.subspec 'MoPubSDK' do |sdk|
     sdk.dependency              'mopub-ios-sdk/Core'


### PR DESCRIPTION
It's come to our attention that there are now many pod spec authors, including you, that added this `user_target_xcconfig` setting to their pod specs.

However, doing so causes some trouble when Cocoapods installs multiple pods that use this setting but have differing values.
On `pod install` warnings like this will be emitted:

`[!] Can't merge user_target_xcconfig for pod targets: [... list of pods ...]. Singular build setting EXCLUDED_ARCHS[sdk=<...>] has different values.`

The podspec syntax reference says this attribute is "not recommended" and discourages its use.

https://guides.cocoapods.org/syntax/podspec.html#user_target_xcconfig