### PR TITLE
Eliminate MPTimer's memory leak, leading to exponential growth of `synchronizeConsentWithCompletion` calls

### DIFF
--- a/MoPubSDK/Internal/Common/MPAdServerCommunicator.m
+++ b/MoPubSDK/Internal/Common/MPAdServerCommunicator.m
@@ -134,13 +134,15 @@ static NSString * const kAdResonsesContentKey = @"content";
         return;
     }
 
+    __typeof__(self) __weak weakSelf = self;
+
     for (NSURL * beforeLoadURL in configuration.beforeLoadURLs) {
         MPURLRequest * request = [MPURLRequest requestWithURL:beforeLoadURL];
         if (request == nil) {
             continue;
         }
         [MPHTTPNetworkSession startTaskWithHttpRequest:request responseHandler:^(NSData * _Nonnull data, NSHTTPURLResponse * _Nonnull response) {
-            MPLogDebug(@"Successfully sent before load URL: %@", beforeLoadURL);
+            MPLogDebug1(weakSelf, @"Successfully sent before load URL: %@", beforeLoadURL);
         } errorHandler:^(NSError * _Nonnull error) {
             MPLogInfo(@"Failed to send before load URL: %@", beforeLoadURL);
         }];
@@ -153,15 +155,17 @@ static NSString * const kAdResonsesContentKey = @"content";
 {
     NSArray * afterLoadUrls = [configuration afterLoadUrlsWithLoadDuration:duration loadResult:result];
 
+    __typeof__(self) __weak weakSelf = self;
+
     for (NSURL * afterLoadUrl in afterLoadUrls) {
         MPURLRequest * request = [MPURLRequest requestWithURL:afterLoadUrl];
         if (request == nil) {
             continue;
         }
         [MPHTTPNetworkSession startTaskWithHttpRequest:request responseHandler:^(NSData * _Nonnull data, NSHTTPURLResponse * _Nonnull response) {
-            MPLogDebug(@"Successfully sent after load URL: %@", afterLoadUrl);
+            MPLogDebug1(weakSelf, @"Successfully sent after load URL: %@", afterLoadUrl);
         } errorHandler:^(NSError * _Nonnull error) {
-            MPLogDebug(@"Failed to send after load URL: %@", afterLoadUrl);
+            MPLogDebug1(weakSelf, @"Failed to send after load URL: %@", afterLoadUrl);
         }];
     }
 }

--- a/MoPubSDK/Internal/MPConsentManager.m
+++ b/MoPubSDK/Internal/MPConsentManager.m
@@ -653,7 +653,7 @@ static NSString * const kDeprecatedIfaPrefixToRemove = @"ifa:";
  */
 - (MPTimer * _Nonnull)newNextUpdateTimer {
     __typeof__(self) __weak weakSelf = self;
-    MPTimer * timer = [MPTimer timerWithTimeInterval:self.syncFrequency repeats:YES block:^(MPTimer * _Nonnull timer) {
+    MPTimer * timer = [MPTimer timerWithTimeInterval:self.syncFrequency repeats:NO block:^(MPTimer * _Nonnull timer) {
         __typeof__(self) strongSelf = weakSelf;
         [strongSelf onNextUpdateFiredWithTimer];
     }];

--- a/MoPubSDK/Internal/Utility/MPImageDownloadQueue.m
+++ b/MoPubSDK/Internal/Utility/MPImageDownloadQueue.m
@@ -57,6 +57,8 @@
     __block NSMutableDictionary *result = [NSMutableDictionary new];
     __block NSMutableArray *errors = nil;
 
+    __typeof__(self) __weak weakSelf = self;
+
     for (NSURL *imageURL in imageURLs) {
         [self.imageDownloadQueue addOperationWithBlock:^{
             @autoreleasepool {
@@ -65,7 +67,7 @@
                     UIImage *image = [MPImageCreator imageWith:imageData];
                     result[imageURL] = image;
                 } else if (![[MPNativeCache sharedCache] cachedDataExistsForKey:imageURL.absoluteString] || !useCachedImage) {
-                    MPLogDebug(@"Downloading %@", imageURL);
+                    MPLogDebug1(weakSelf, @"Downloading %@", imageURL);
 
                     __block NSError *error = nil;
                     __block NSData *data = nil;
@@ -89,7 +91,7 @@
                             result[imageURL] = downloadedImage;
                         } else {
                             if (downloadedImage == nil) {
-                                MPLogDebug(@"Error: invalid image data downloaded");
+                                MPLogDebug1(weakSelf, @"Error: invalid image data downloaded");
                             }
 
                             validImageDownloaded = NO;

--- a/MoPubSDK/Internal/Utility/MPTimer.m
+++ b/MoPubSDK/Internal/Utility/MPTimer.m
@@ -63,12 +63,12 @@
 
             // Extra validation for the timer callback block.
             if (strongSelf.timerCallbackBlock == nil) {
-                MPLogDebug(@"%s `timerCallbackBlock` is unexpectedly nil. Return early to avoid crash.", __FUNCTION__);
+                MPLogDebug1(strongSelf, @"%s `timerCallbackBlock` is unexpectedly nil. Return early to avoid crash.", __FUNCTION__);
                 return;
             }
 
             // Forward the callback along
-            strongSelf.timerCallbackBlock(self);
+            strongSelf.timerCallbackBlock(strongSelf);
         }];
         [_timer setFireDate:NSDate.distantFuture];
 

--- a/MoPubSDK/Logging/MPLogging.h
+++ b/MoPubSDK/Logging/MPLogging.h
@@ -17,6 +17,7 @@ extern NSString * const kMPClearErrorLogFormatWithAdUnitID;
 extern NSString * const kMPWarmingUpErrorLogFormatWithAdUnitID;
 
 #define MPLogDebug(...) [MPLogging logEvent:[MPLogEvent eventWithMessage:[NSString stringWithFormat:__VA_ARGS__] level:MPBLogLevelDebug] source:nil fromClass:self.class]
+#define MPLogDebug1(weakSelf, ...) [MPLogging logEvent:[MPLogEvent eventWithMessage:[NSString stringWithFormat:__VA_ARGS__] level:MPBLogLevelDebug] source:nil fromClass:weakSelf.class]
 #define MPLogInfo(...) [MPLogging logEvent:[MPLogEvent eventWithMessage:[NSString stringWithFormat:__VA_ARGS__] level:MPBLogLevelInfo] source:nil fromClass:self.class]
 
 // MPLogTrace, MPLogWarn, MPLogError, and MPLogFatal will be deprecated in


### PR DESCRIPTION
When calling `strongSelf.timerCallbackBlock;` in NSTimer handler, 'self' is used directly as a block parameter, which leads to capturing of 'self' by NSTimer and thus a retain cycle in MPTimer.

But implicitly `self` is also used in MPLogDebug macro, which is used not only in MPTimer.

**Consequences**

Problem goes critical for MPConsentManager: after app is relaunched from background (after some inactivity), this retain cycle creates exponential creation of MPTimer's and their closure call and basically leads to freeze and crash after some time.

Mechanism is that after app relaunch a new `newNextUpdateTimer` creates a new timer whereas the old one stays alive. Each timer block invocation leads to another `onNextUpdateFiredWithTimer ` call, which creates newNextUpdateTimer in callbacks `didFinishSynchronizationWithData:synchronizedStatus:completion:` and `didFailSynchronizationWithError:completion:` once again.

**Solution**

Basically to avoid the problem it would be enough just to make `repeats:NO` for new MPTimer in `newNextUpdateTimer`, cause it's recreated on each `synchronizeConsentWithCompletion:` anyway.

But to make MPTimer more robust I would propose to introduce MPLogDebug macro with explicit parameter for `self`, and this one is done in this PR. The name is chosen as an analogy of Apple's NSAssert/NSAssert1/NSAssert2/...

Or it could be a macro, suggesting per se that `weakSelf` is available in closure so that compiler gives error otherwise:
`#define MPInBlockLogDebug(...) [MPLogging logEvent:[MPLogEvent eventWithMessage:[NSString stringWithFormat:__VA_ARGS__] level:MPBLogLevelDebug] source:nil fromClass:weakSelf.class]
`

The same problem is there regarding `MPLogInfo` and the places of its usage, and also for deprecated MPLogTrace/MPLogWarn/MPLogError/MPLogFatal, but all these are not a part of this PR.
